### PR TITLE
[39] feat: try macro

### DIFF
--- a/include/utils/types/result.hpp
+++ b/include/utils/types/result.hpp
@@ -25,8 +25,8 @@ namespace types {
 
     template<typename T, typename E>
     class Result {
-        Ok<T>* ok_;   // Ok 状態の場合はここに値が入る
-        Err<E>* err_; // Err 状態の場合はここに値が入る
+        Ok<T>* ok_;
+        Err<E>* err_;
 
     public:
         // NOLINTNEXTLINE(google-explicit-constructor)
@@ -39,22 +39,26 @@ namespace types {
             delete err_;
         }
 
-        bool is_ok() const { return ok_ != NULL; }
-        bool is_err() const { return err_ != NULL; }
+        bool isOk() const { return ok_ != NULL; }
+        bool isErr() const { return err_ != NULL; }
 
         T unwrap() const {
-            if (!is_ok()) {
+            if (!isOk()) {
                 throw std::runtime_error("Called unwrap on Err");
             }
-            return ok_->value(); // getter を使用
+            return ok_->value();
         }
 
-        E unwrap_err() const {
-            if (!is_err()) {
+        E unwrapErr() const {
+            if (!isErr()) {
                  throw std::runtime_error("Called unwrap_err on Ok");
             }
-            return err_->error(); // getter を使用
+            return err_->error();
         }
+
+	    bool canUnwrap() const {
+			return isOk();
+		}
     };
 
     template<typename T>

--- a/include/utils/types/try.hpp
+++ b/include/utils/types/try.hpp
@@ -1,0 +1,27 @@
+#ifndef SRC_LIB_UTILS_TYPES_TRY_HPP
+#define SRC_LIB_UTILS_TYPES_TRY_HPP
+
+#include "result.hpp"
+#include "option.hpp"
+
+template <typename T, typename E>
+types::Err<E> tryDefault(const types::Result<T, E> &res) {
+	return types::err(res.unwrapErr());
+}
+
+template <typename T>
+types::Option<T> tryDefault(const types::Option<T> &opt) {
+	(void)opt;
+    return types::Option<T>(types::none);
+}
+
+// typeof(expr) e = (expr); の箇所で明示的に一度実行する。
+// それにより、exprが複数回実行されることを防ぐ。
+#define TRY(expr)                                                                \
+    ({                                                                           \
+        typeof(expr) e = (expr); /* NOLINT(*-unnecessary-copy-initialization) */ \
+        if (!(e).canUnwrap()) return tryDefault(e);                              \
+        (e).unwrap();                                                            \
+    })
+
+#endif

--- a/include/utils/types/try.hpp
+++ b/include/utils/types/try.hpp
@@ -1,5 +1,5 @@
-#ifndef SRC_LIB_UTILS_TYPES_TRY_HPP
-#define SRC_LIB_UTILS_TYPES_TRY_HPP
+#ifndef UTILS_TYPES_TRY_HPP
+#define UTILS_TYPES_TRY_HPP
 
 #include "result.hpp"
 #include "option.hpp"

--- a/test/utils/types/CMakeLists.txt
+++ b/test/utils/types/CMakeLists.txt
@@ -16,6 +16,13 @@ target_link_libraries(option_test
 	PRIVATE webserv_lib gtest
 )
 
+# Option用のテスト実行ファイル
+add_executable(try_test try_test.cpp)
+target_link_libraries(try_test
+	PRIVATE webserv_lib gtest
+)
+
 # テストディスカバリー
 gtest_discover_tests(result_test)
 gtest_discover_tests(option_test)
+gtest_discover_tests(try_test)

--- a/test/utils/types/option_test.cpp
+++ b/test/utils/types/option_test.cpp
@@ -15,15 +15,15 @@ int Tracer::count = 0;
 
 TEST(OptionTest, SomeConstruction) {
     types::Option<int> option(types::some(42));
-    EXPECT_TRUE(option.is_some());
-    EXPECT_FALSE(option.is_none());
+    EXPECT_TRUE(option.isSome());
+    EXPECT_FALSE(option.isNone());
     EXPECT_EQ(42, option.unwrap());
 }
 
 TEST(OptionTest, NoneConstruction) {
     types::Option<int> option(types::none);
-    EXPECT_FALSE(option.is_some());
-    EXPECT_TRUE(option.is_none());
+    EXPECT_FALSE(option.isSome());
+    EXPECT_TRUE(option.isNone());
 }
 
 TEST(OptionTest, UnwrapOnNoneThrows) {
@@ -33,12 +33,12 @@ TEST(OptionTest, UnwrapOnNoneThrows) {
 
 TEST(OptionTest, UnwrapOrWithSome) {
     types::Option<int> option(types::some(42));
-    EXPECT_EQ(42, option.unwrap_or(0));
+    EXPECT_EQ(42, option.unwrapOr(0));
 }
 
 TEST(OptionTest, UnwrapOrWithNone) {
     types::Option<int> option(types::none);
-    EXPECT_EQ(0, option.unwrap_or(0));
+    EXPECT_EQ(0, option.unwrapOr(0));
 }
 
 TEST(OptionTest, SomeDestruction) {
@@ -62,7 +62,7 @@ TEST(OptionTest, StringOption) {
     types::Option<std::string> none_option(types::none);
     
     EXPECT_EQ("hello", some_option.unwrap());
-    EXPECT_EQ("default", none_option.unwrap_or("default"));
+    EXPECT_EQ("default", none_option.unwrapOr("default"));
 }
 
 }  // namespace

--- a/test/utils/types/result_test.cpp
+++ b/test/utils/types/result_test.cpp
@@ -14,16 +14,16 @@ int Tracer::count = 0;
 
 TEST(ResultTest, OkConstruction) {
     types::Result<int, std::string> result(types::ok(42));
-    EXPECT_TRUE(result.is_ok());
-    EXPECT_FALSE(result.is_err());
+    EXPECT_TRUE(result.isOk());
+    EXPECT_FALSE(result.isErr());
     EXPECT_EQ(42, result.unwrap());
 }
 
 TEST(ResultTest, ErrConstruction) {
     types::Result<int, std::string> result(types::err(std::string("error")));
-    EXPECT_FALSE(result.is_ok());
-    EXPECT_TRUE(result.is_err());
-    EXPECT_EQ("error", result.unwrap_err());
+    EXPECT_FALSE(result.isOk());
+    EXPECT_TRUE(result.isErr());
+    EXPECT_EQ("error", result.unwrapErr());
 }
 
 TEST(ResultTest, UnwrapOnErrThrows) {
@@ -33,7 +33,7 @@ TEST(ResultTest, UnwrapOnErrThrows) {
 
 TEST(ResultTest, UnwrapErrOnOkThrows) {
     types::Result<int, std::string> result(types::ok(42));
-    EXPECT_THROW(result.unwrap_err(), std::runtime_error);
+    EXPECT_THROW(result.unwrapErr(), std::runtime_error);
 }
 
 TEST(ResultTest, OkDestruction) {

--- a/test/utils/types/try_test.cpp
+++ b/test/utils/types/try_test.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include "utils/types/try.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/option.hpp"
+
+namespace {
+
+TEST(TryMacroTest, ResultErrorShortCircuit) {
+    auto func = []() -> types::Result<int, std::string> {
+        // テンプレート引数のカンマを正しく解釈させるため括弧で囲む
+        int value = TRY((types::Result<int, std::string>(types::err(std::string("error occurred")))));
+        return types::Result<int, std::string>(types::ok(value + 1));
+    };
+
+    auto res = func();
+    EXPECT_TRUE(res.isErr());
+    EXPECT_EQ("error occurred", res.unwrapErr());
+}
+
+TEST(TryMacroTest, OptionErrorShortCircuit) {
+    auto func = []() -> types::Option<int> {
+        int value = TRY((types::Option<int>(types::none)));
+        return types::Option<int>(types::some(value + 1));
+    };
+
+    auto opt = func();
+    EXPECT_TRUE(opt.isNone());
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## 概要 / Overview

- TRYマクロの作成

## 該当する issue

- #39 

## 使用法
- 現状
```c++
Result<int, std::string> res = someFunction();
if (!res.is_ok()) {
    return res.unwrap_err();
}
int value = res.unwrap();
// ここでvalueを使った処理を続ける
```
- 変更後
```c++
int value = TRY(someFunction());
// ここでvalueを使った処理を続ける
```
## 追加説明
マクロを使うことにより、呼び出している関数レベルでの
早期リターンが可能

例えば以下のようなコードはプリプロセッサで次のように展開されます。
```c++
Result<int, Error> doSomething() {
    int value = TRY(someOperation());
    // ...他の処理...
}
```
```c++
Result<int, Error> doSomething() {
    typeof(someOperation()) e = someOperation();
    if (!(e).canUnwrap()) return tryDefault(e);
    int value = (e).unwrap();
    // ...他の処理...
}
```
そのため、TRYで、doSomethingレベルでの早期リターンが可能です。

## 影響範囲
- 全体

## その他
