### PR TITLE
[57] bug config parser error handling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: Google
-IndentWidth: 8
+IndentWidth: 4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,12 +20,12 @@ CheckOptions:
   
   # 関数の最大行数を30行に制限
   - key: readability-function-size.LineThreshold
-    value: 30
-  
+    value: 31
+
   # 関数の最大文数も制限（オプション）
   - key: readability-function-size.StatementThreshold
     value: 50
-  
+
   # 関数の最大パラメータ数を制限（オプション）
   - key: readability-function-size.ParameterThreshold
     value: 8

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -1,4 +1,4 @@
-server {
+{server {
   listen 80;
   host localhost;
   server_names www.webserv.com webserv.com;

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -1,4 +1,4 @@
-{server {
+server {
   listen 80;
   host localhost;
   server_names www.webserv.com webserv.com;
@@ -6,13 +6,14 @@
     error_page 403 403.html;
     client_max_body_size 1000000;
 
+
   location / {
     allow_method GET;
 
     root /var/www/html;
     index index.html index.htm;
-
   }
+
 
   location /upload {
     allow_method GET POST DELETE;

--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -14,23 +14,23 @@ class ConfigTokenizer;
 #define FILE_NAME "./config_file/default.conf"
 
 class Config {
-       public:
-        explicit Config(const std::string& filename);
-        ~Config();
+   public:
+    explicit Config(const std::string& filename);
+    ~Config();
 
-        static bool checkArgc(int argc);
-        static std::string setFile(int argc, char** argv);
-        static void checkFile(std::string& filename);
-        static bool checkAndEraseLocationNode(const ServerContext& server);
-        void checkAndEraseServerNode();
-        static void removeDuplicateListenServers(
-            std::vector<ServerContext>& servers);
-        const ConfigParser& getParser() const;
-        void printParser() const;
-        static void printServer(const std::vector<ServerContext>& server);
-        static void printLocation(const ServerContext& server);
+    static bool checkArgc(int argc);
+    static std::string setFile(int argc, char** argv);
+    static void checkFile(std::string& filename);
+    static bool checkAndEraseLocationNode(const ServerContext& server);
+    void checkAndEraseServerNode();
+    static void removeDuplicateListenServers(
+        std::vector<ServerContext>& servers);
+    const ConfigParser& getParser() const;
+    void printParser() const;
+    static void printServer(const std::vector<ServerContext>& server);
+    static void printLocation(const ServerContext& server);
 
-       private:
-        ConfigTokenizer tokenizer_;
-        ConfigParser parser_;
+   private:
+    ConfigTokenizer tokenizer_;
+    ConfigParser parser_;
 };

--- a/include/config/context/document_root.hpp
+++ b/include/config/context/document_root.hpp
@@ -7,22 +7,22 @@
 #include "token.hpp"
 
 class DocumentRootConfig {
-       public:
-        explicit DocumentRootConfig();
-        ~DocumentRootConfig();
+   public:
+    explicit DocumentRootConfig();
+    ~DocumentRootConfig();
 
-        void setRoot(const std::string& root);
-        void setIndex(const std::string& index);
-        void setAutoIndex(OnOff autoIndex);
-        void setCgiExtensions(OnOff cgiExtensions);
-        const std::string& getRoot() const;
-        const std::string& getIndex() const;
-        OnOff getAutoIndex() const;
-        OnOff getCgiExtensions() const;
+    void setRoot(const std::string& root);
+    void setIndex(const std::string& index);
+    void setAutoIndex(OnOff autoIndex);
+    void setCgiExtensions(OnOff cgiExtensions);
+    const std::string& getRoot() const;
+    const std::string& getIndex() const;
+    OnOff getAutoIndex() const;
+    OnOff getCgiExtensions() const;
 
-       private:
-        std::string root_;
-        std::string index_;
-        OnOff autoIndex_;
-        OnOff cgiExtensions_;
+   private:
+    std::string root_;
+    std::string index_;
+    OnOff autoIndex_;
+    OnOff cgiExtensions_;
 };

--- a/include/config/context/location.hpp
+++ b/include/config/context/location.hpp
@@ -8,25 +8,25 @@
 #include "token.hpp"
 
 class LocationContext {
-       public:
-        explicit LocationContext(const std::string& text);
-        ~LocationContext();
+   public:
+    explicit LocationContext(const std::string& text);
+    ~LocationContext();
 
-        void setPath(const std::string& path);
-        void setMethod(AllowedMethod method);
-        void setRedirect(const std::string& redirect);
-        const std::string& getPath() const;
-        OnOff* getMutableAllowedMethod();
-        const OnOff* getAllowedMethod() const;
-        const std::string& getRedirect() const;
-        DocumentRootConfig& getDocumentRootConfig();
-        const DocumentRootConfig& getDocumentRootConfig() const;
+    void setPath(const std::string& path);
+    void setMethod(AllowedMethod method);
+    void setRedirect(const std::string& redirect);
+    const std::string& getPath() const;
+    OnOff* getMutableAllowedMethod();
+    const OnOff* getAllowedMethod() const;
+    const std::string& getRedirect() const;
+    DocumentRootConfig& getDocumentRootConfig();
+    const DocumentRootConfig& getDocumentRootConfig() const;
 
-       private:
-        static const int METHOD_COUNT = 3;
-        std::string value_;
-        std::string path_;
-        OnOff allowedMethod_[METHOD_COUNT];
-        std::string redirect_;
-        DocumentRootConfig documentRootConfig_;
+   private:
+    static const int METHOD_COUNT = 3;
+    std::string value_;
+    std::string path_;
+    OnOff allowedMethod_[METHOD_COUNT];
+    std::string redirect_;
+    DocumentRootConfig documentRootConfig_;
 };

--- a/include/config/context/server.hpp
+++ b/include/config/context/server.hpp
@@ -16,33 +16,33 @@ class LocationContext;
 #include "tokenizer.hpp"
 
 class ServerContext {
-       public:
-        static const int PAGE_NUMBER = 404;
-        explicit ServerContext(const std::string& text);
-        ~ServerContext();
+   public:
+    static const int PAGE_NUMBER = 404;
+    explicit ServerContext(const std::string& text);
+    ~ServerContext();
 
-        std::string newToken(std::string& token);
-        void setListen(u_int16_t port);
-        void setHost(const std::string& host);
-        void setserverName(const std::string& serverName);
-        void addMap(int number, const std::string& fileName);
-        void setClientMaxBodySize(size_t size);
+    std::string newToken(std::string& token);
+    void setListen(u_int16_t port);
+    void setHost(const std::string& host);
+    void setserverName(const std::string& serverName);
+    void addMap(int number, const std::string& fileName);
+    void setClientMaxBodySize(size_t size);
 
-        const std::string& getValue() const;
-        u_int16_t getListen() const;
-        const std::string& getHost() const;
-        const std::string& getserverName() const;
-        const std::vector<std::map<int, std::string> >& getErrorPage() const;
-        size_t getClientMaxBodySize() const;
-        std::vector<LocationContext>& getLocation();
-        const std::vector<LocationContext>& getLocation() const;
+    const std::string& getValue() const;
+    u_int16_t getListen() const;
+    const std::string& getHost() const;
+    const std::string& getserverName() const;
+    const std::vector<std::map<int, std::string> >& getErrorPage() const;
+    size_t getClientMaxBodySize() const;
+    std::vector<LocationContext>& getLocation();
+    const std::vector<LocationContext>& getLocation() const;
 
-       private:
-        std::string value_;
-        u_int16_t listen_;
-        std::string host_;
-        std::string serverName_;
-        std::vector<std::map<int, std::string> > errorPage_;
-        size_t clientMaxBodySize_;
-        std::vector<LocationContext> locations_;
+   private:
+    std::string value_;
+    u_int16_t listen_;
+    std::string host_;
+    std::string serverName_;
+    std::vector<std::map<int, std::string> > errorPage_;
+    size_t clientMaxBodySize_;
+    std::vector<LocationContext> locations_;
 };

--- a/include/config/parser.hpp
+++ b/include/config/parser.hpp
@@ -35,7 +35,7 @@ class ConfigParser {
         std::vector<ServerContext> servers_;
 
         void makeVectorServer_();
-        void updateDepth(const std::string& token, int lineNumber);
+        void updateDepth(const Token& token, int lineNumber);
         void addServer_(size_t& index);
         void setPort_(ServerContext& server, size_t& index);
         void setHost_(ServerContext& server, size_t& index);

--- a/include/config/parser.hpp
+++ b/include/config/parser.hpp
@@ -11,44 +11,44 @@ class ServerContext;
 #include "tokenizer.hpp"
 
 class ConfigParser {
-       public:
-        explicit ConfigParser(ConfigTokenizer& tokenizer);
-        ~ConfigParser();
+   public:
+    explicit ConfigParser(ConfigTokenizer& tokenizer);
+    ~ConfigParser();
 
-        std::vector<ServerContext>& getServer();
-        const std::vector<ServerContext>& getServer() const;
-        static void throwErr(const std::string& str1, const std::string& str2,
-                             int lineNumber);
+    std::vector<ServerContext>& getServer();
+    const std::vector<ServerContext>& getServer() const;
+    static void throwErr(const std::string& str1, const std::string& str2,
+                         int lineNumber);
 
-       private:
-        static const int FUNC_SERVER_SIZE = 6;
-        static const int FUNC_LOCATION_SIZE = 6;
-        typedef void (ConfigParser::*funcServerPtr)(ServerContext& server,
-                                                    size_t& index);
-        static funcServerPtr funcServer_[FUNC_SERVER_SIZE];
-        typedef void (ConfigParser::*funcLocationPtr)(LocationContext& location,
-                                                      size_t& index);
-        static funcLocationPtr funcLocation_[FUNC_LOCATION_SIZE];
+   private:
+    static const int FUNC_SERVER_SIZE = 6;
+    static const int FUNC_LOCATION_SIZE = 6;
+    typedef void (ConfigParser::*funcServerPtr)(ServerContext& server,
+                                                size_t& index);
+    static funcServerPtr funcServer_[FUNC_SERVER_SIZE];
+    typedef void (ConfigParser::*funcLocationPtr)(LocationContext& location,
+                                                  size_t& index);
+    static funcLocationPtr funcLocation_[FUNC_LOCATION_SIZE];
 
-        std::vector<Token> tokens_;
-        int depth_;
-        std::vector<ServerContext> servers_;
+    std::vector<Token> tokens_;
+    int depth_;
+    std::vector<ServerContext> servers_;
 
-        void makeVectorServer_();
-        void updateDepth(const Token& token, int lineNumber);
-        void addServer_(size_t& index);
-        void setPort_(ServerContext& server, size_t& index);
-        void setHost_(ServerContext& server, size_t& index);
-        void setserverName_(ServerContext& server, size_t& index);
-        void setMaxBodySize_(ServerContext& server, size_t& index);
-        void setErrPage_(ServerContext& server, size_t& index);
-        void addLocation_(ServerContext& server, size_t& index);
-        static void setDefaultMethod_(LocationContext& location);
-        void setRoot_(LocationContext& location, size_t& index);
-        void setMethod_(LocationContext& location, size_t& index);
-        void setIndex_(LocationContext& location, size_t& index);
-        void setAutoIndex_(LocationContext& location, size_t& index);
-        void setIsCgi_(LocationContext& location, size_t& index);
-        void setRedirect_(LocationContext& location, size_t& index);
-        std::string incrementAndCheckSize_(size_t& index);
+    void makeVectorServer_();
+    void updateDepth(const Token& token, int lineNumber);
+    void addServer_(size_t& index);
+    void setPort_(ServerContext& server, size_t& index);
+    void setHost_(ServerContext& server, size_t& index);
+    void setserverName_(ServerContext& server, size_t& index);
+    void setMaxBodySize_(ServerContext& server, size_t& index);
+    void setErrPage_(ServerContext& server, size_t& index);
+    void addLocation_(ServerContext& server, size_t& index);
+    static void setDefaultMethod_(LocationContext& location);
+    void setRoot_(LocationContext& location, size_t& index);
+    void setMethod_(LocationContext& location, size_t& index);
+    void setIndex_(LocationContext& location, size_t& index);
+    void setAutoIndex_(LocationContext& location, size_t& index);
+    void setIsCgi_(LocationContext& location, size_t& index);
+    void setRedirect_(LocationContext& location, size_t& index);
+    std::string incrementAndCheckSize_(size_t& index);
 };

--- a/include/config/token.hpp
+++ b/include/config/token.hpp
@@ -4,44 +4,40 @@
 #include <ostream>
 
 enum TokenType {
-        LISTEN,
-        HOST,
-        SERVER_NAMES,
-        ERR_PAGE,
-        MAX_SIZE,
-        LOCATION,
-        ROOT,
-        METHOD,
-        INDEX,
-        AUTOINDEX,
-        IS_CGI,
-        REDIRECT,
-        SERVER,
-        VALUE,
-        BRACE
+    LISTEN,
+    HOST,
+    SERVER_NAMES,
+    ERR_PAGE,
+    MAX_SIZE,
+    LOCATION,
+    ROOT,
+    METHOD,
+    INDEX,
+    AUTOINDEX,
+    IS_CGI,
+    REDIRECT,
+    SERVER,
+    VALUE,
+    BRACE
 };
 
-enum   TokenPosition {
-        BEGINNING,
-        MIDDLE,
-        END
-};
+enum TokenPosition { BEGINNING, MIDDLE, END };
 
 class Token {
-       public:
-        Token(const std::string& text, int lineNumber, TokenPosition position);
-        ~Token();
+   public:
+    Token(const std::string& text, int lineNumber, TokenPosition position);
+    ~Token();
 
-        std::string getText() const;
-        int getLineNumber() const;
-        TokenType getType() const;
-        TokenPosition getPosition() const;
+    std::string getText() const;
+    int getLineNumber() const;
+    TokenType getType() const;
+    TokenPosition getPosition() const;
 
-       private:
-        std::string text_;
-        int lineNumber_;
-        TokenType type_;
-        TokenPosition position_;
-        void setType_(const std::string& text);
-        static void checkString_(const std::string& text, int lineNumber);
+   private:
+    std::string text_;
+    int lineNumber_;
+    TokenType type_;
+    TokenPosition position_;
+    void setType_(const std::string& text);
+    static void checkString_(const std::string& text, int lineNumber);
 };

--- a/include/config/token.hpp
+++ b/include/config/token.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <iostream>
 #include <map>
+#include <ostream>
 
 enum TokenType {
         LISTEN,
@@ -21,18 +21,27 @@ enum TokenType {
         BRACE
 };
 
+enum   TokenPosition {
+        BEGINNING,
+        MIDDLE,
+        END
+};
+
 class Token {
        public:
-        Token(const std::string& text, int lineNumber);
+        Token(const std::string& text, int lineNumber, TokenPosition position);
         ~Token();
 
         std::string getText() const;
         int getLineNumber() const;
         TokenType getType() const;
+        TokenPosition getPosition() const;
 
        private:
         std::string text_;
         int lineNumber_;
         TokenType type_;
+        TokenPosition position_;
         void setType_(const std::string& text);
+        static void checkString_(const std::string& text, int lineNumber);
 };

--- a/include/config/tokenizer.hpp
+++ b/include/config/tokenizer.hpp
@@ -14,16 +14,16 @@ class Token;
 #define FILE_NAME "./config_file/default.conf"
 
 class ConfigTokenizer {
-       public:
-        explicit ConfigTokenizer(std::string& filename);
-        ~ConfigTokenizer();
+   public:
+    explicit ConfigTokenizer(std::string& filename);
+    ~ConfigTokenizer();
 
-        const std::vector<Token>& getTokens() const;
-        static std::string numberToStr(int number);
+    const std::vector<Token>& getTokens() const;
+    static std::string numberToStr(int number);
 
-       private:
-        std::vector<Token> tokens_;
+   private:
+    std::vector<Token> tokens_;
 
-        void makeTokenList_(std::ifstream& file);
-        static void checkLineEnd(const std::string& line, int lineCount);
+    void makeTokenList_(std::ifstream& file);
+    static void checkLineEnd(const std::string& line, int lineCount);
 };

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -8,115 +8,114 @@
 #include "server.hpp"
 
 struct ConfigServerValueErrorEraser {
-       private:
-        const Config* config;
+   private:
+    const Config* config;
 
-       public:
-        explicit ConfigServerValueErrorEraser(const Config* cfg)
-            : config(cfg) {}
+   public:
+    explicit ConfigServerValueErrorEraser(const Config* cfg) : config(cfg) {}
 
-        bool operator()(const ServerContext& server) const {
-                return (server.getHost().empty() || server.getListen() == 0 ||
-                        Config::checkAndEraseLocationNode(server) ||
-                        server.getLocation().empty());
-        }
+    bool operator()(const ServerContext& server) const {
+        return (server.getHost().empty() || server.getListen() == 0 ||
+                Config::checkAndEraseLocationNode(server) ||
+                server.getLocation().empty());
+    }
 };
 
 struct ConfigServerDuplicateErrorEraser {
-       private:
-        std::vector<int>* seenListenValue;
+   private:
+    std::vector<int>* seenListenValue;
 
-       public:
-        explicit ConfigServerDuplicateErrorEraser(std::vector<int>* seen)
-            : seenListenValue(seen) {}
+   public:
+    explicit ConfigServerDuplicateErrorEraser(std::vector<int>* seen)
+        : seenListenValue(seen) {}
 
-        bool operator()(const ServerContext& server) {
-                const int listen = server.getListen();
+    bool operator()(const ServerContext& server) {
+        const int listen = server.getListen();
 
-                for (std::vector<int>::iterator it = seenListenValue->begin();
-                     it != seenListenValue->end(); ++it) {
-                        if (*it == listen) {
-                                std::cerr << "[ server removed: listen port "
-                                             "duplicate error ]"
-                                          << std::endl;
-                                return (true);
-                        }
-                }
-                seenListenValue->push_back(listen);
-                return (false);
+        for (std::vector<int>::iterator it = seenListenValue->begin();
+             it != seenListenValue->end(); ++it) {
+            if (*it == listen) {
+                std::cerr << "[ server removed: listen port "
+                             "duplicate error ]"
+                          << std::endl;
+                return (true);
+            }
         }
+        seenListenValue->push_back(listen);
+        return (false);
+    }
 };
 
 Config::Config(const std::string& filename)
     : tokenizer_(const_cast<std::string&>(filename)), parser_(tokenizer_) {
-        checkAndEraseServerNode();
-        removeDuplicateListenServers(this->parser_.getServer());
+    checkAndEraseServerNode();
+    removeDuplicateListenServers(this->parser_.getServer());
 }
 
 Config::~Config() {}
 
 bool Config::checkArgc(int argc) {
-        if (argc > 2) {
-                std::cerr << "Argument error" << std::endl;
-                return (false);
-        }
-        return (true);
+    if (argc > 2) {
+        std::cerr << "Argument error" << std::endl;
+        return (false);
+    }
+    return (true);
 }
 
 std::string Config::setFile(int argc, char** argv) {
-        std::string confFile;
-        if (argc == 1) {
-                confFile = FILE_NAME;
-        } else {
-                confFile = argv[1];
-        }
-        return (confFile);
+    std::string confFile;
+    if (argc == 1) {
+        confFile = FILE_NAME;
+    } else {
+        confFile = argv[1];
+    }
+    return (confFile);
 }
 
 void Config::checkFile(std::string& filename) {
-        struct stat status;
+    struct stat status;
 
-        if (stat(filename.c_str(), &status) != 0) {
-                std::cerr << "Failed to stat file: " << filename << std::endl;
-                std::exit(1);
-        }
-        if (status.st_mode & S_IFDIR) {
-                std::cerr << filename << ": is a directory" << std::endl;
-                std::exit(1);
-        }
+    if (stat(filename.c_str(), &status) != 0) {
+        std::cerr << "Failed to stat file: " << filename << std::endl;
+        std::exit(1);
+    }
+    if (status.st_mode & S_IFDIR) {
+        std::cerr << filename << ": is a directory" << std::endl;
+        std::exit(1);
+    }
 }
 
 void Config::checkAndEraseServerNode() {
-        std::vector<ServerContext>& servers = this->parser_.getServer();
+    std::vector<ServerContext>& servers = this->parser_.getServer();
 
-        servers.erase(std::remove_if(servers.begin(), servers.end(),
-                                     ConfigServerValueErrorEraser(this)),
-                      servers.end());
-        std::cerr << "[ server removed: location block member value error ]"
-                  << std::endl;
+    servers.erase(std::remove_if(servers.begin(), servers.end(),
+                                 ConfigServerValueErrorEraser(this)),
+                  servers.end());
+    std::cerr << "[ server removed: location block member value error ]"
+              << std::endl;
 }
 
 bool Config::checkAndEraseLocationNode(const ServerContext& server) {
-        for (std::vector<LocationContext>::const_iterator it =
-                 server.getLocation().begin();
-             it != server.getLocation().end(); ++it) {
-                return (it->getPath().empty() ||
-                        it->getDocumentRootConfig().getRoot().empty());
-        }
-        return (false);
+    for (std::vector<LocationContext>::const_iterator it =
+             server.getLocation().begin();
+         it != server.getLocation().end(); ++it) {
+        return (it->getPath().empty() ||
+                it->getDocumentRootConfig().getRoot().empty());
+    }
+    return (false);
 }
 
 void Config::removeDuplicateListenServers(std::vector<ServerContext>& servers) {
-        std::vector<int> seenListenValue;
+    std::vector<int> seenListenValue;
 
-        servers.erase(
-            std::remove_if(servers.begin(), servers.end(),
-                           ConfigServerDuplicateErrorEraser(&seenListenValue)),
-            servers.end());
+    servers.erase(
+        std::remove_if(servers.begin(), servers.end(),
+                       ConfigServerDuplicateErrorEraser(&seenListenValue)),
+        servers.end());
 }
 
 const ConfigParser& Config::getParser() const { return (this->parser_); }
 
 void Config::printParser() const {
-        printServer(Config::getParser().getServer());
+    printServer(Config::getParser().getServer());
 }

--- a/src/config/context/document_root.cpp
+++ b/src/config/context/document_root.cpp
@@ -5,18 +5,30 @@ DocumentRootConfig::DocumentRootConfig()
 
 DocumentRootConfig::~DocumentRootConfig() {}
 
-void DocumentRootConfig::setRoot(const std::string& root) { this->root_ = root; }
+void DocumentRootConfig::setRoot(const std::string& root) {
+    this->root_ = root;
+}
 
-void DocumentRootConfig::setIndex(const std::string& index) { this->index_ = index; }
+void DocumentRootConfig::setIndex(const std::string& index) {
+    this->index_ = index;
+}
 
-void DocumentRootConfig::setAutoIndex(OnOff autoIndex) { this->autoIndex_ = autoIndex; }
+void DocumentRootConfig::setAutoIndex(OnOff autoIndex) {
+    this->autoIndex_ = autoIndex;
+}
 
-void DocumentRootConfig::setCgiExtensions(OnOff cgiExtensions) { this-> cgiExtensions_ = cgiExtensions; }
+void DocumentRootConfig::setCgiExtensions(OnOff cgiExtensions) {
+    this->cgiExtensions_ = cgiExtensions;
+}
 
 const std::string& DocumentRootConfig::getRoot() const { return (this->root_); }
 
-const std::string& DocumentRootConfig::getIndex() const { return (this->index_); }
+const std::string& DocumentRootConfig::getIndex() const {
+    return (this->index_);
+}
 
 OnOff DocumentRootConfig::getAutoIndex() const { return (this->autoIndex_); }
 
-OnOff DocumentRootConfig::getCgiExtensions() const { return (this->cgiExtensions_); }
+OnOff DocumentRootConfig::getCgiExtensions() const {
+    return (this->cgiExtensions_);
+}

--- a/src/config/context/location.cpp
+++ b/src/config/context/location.cpp
@@ -1,12 +1,13 @@
 #include "location.hpp"
 
 #include <string>
+
 #include "data.hpp"
 
 LocationContext::LocationContext(const std::string& text) : value_(text) {
-        this->allowedMethod_[GET] = OFF;
-        this->allowedMethod_[POST] = OFF;
-        this->allowedMethod_[DELETE] = OFF;
+    this->allowedMethod_[GET] = OFF;
+    this->allowedMethod_[POST] = OFF;
+    this->allowedMethod_[DELETE] = OFF;
 }
 
 LocationContext::~LocationContext() {}
@@ -14,29 +15,31 @@ LocationContext::~LocationContext() {}
 void LocationContext::setPath(const std::string& path) { this->path_ = path; }
 
 void LocationContext::setMethod(AllowedMethod method) {
-        this->allowedMethod_[method] = ON;
+    this->allowedMethod_[method] = ON;
 }
 
 void LocationContext::setRedirect(const std::string& redirect) {
-        this->redirect_ = redirect;
+    this->redirect_ = redirect;
 }
 
 const std::string& LocationContext::getPath() const { return (this->path_); }
 
-OnOff* LocationContext::getMutableAllowedMethod() { return (this->allowedMethod_); }
+OnOff* LocationContext::getMutableAllowedMethod() {
+    return (this->allowedMethod_);
+}
 
 const OnOff* LocationContext::getAllowedMethod() const {
-        return (this->allowedMethod_);        
+    return (this->allowedMethod_);
 }
 
 const std::string& LocationContext::getRedirect() const {
-        return (this->redirect_);
+    return (this->redirect_);
 }
 
 DocumentRootConfig& LocationContext::getDocumentRootConfig() {
-        return (this->documentRootConfig_);
+    return (this->documentRootConfig_);
 }
 
 const DocumentRootConfig& LocationContext::getDocumentRootConfig() const {
-        return (this->documentRootConfig_);
+    return (this->documentRootConfig_);
 }

--- a/src/config/context/server.cpp
+++ b/src/config/context/server.cpp
@@ -2,10 +2,10 @@
 
 ServerContext::ServerContext(const std::string& text)
     : value_(text), listen_(0), clientMaxBodySize_(0) {
-        std::map<int, std::string> errPage;
-        errPage.insert(std::make_pair(PAGE_NUMBER, "404.html"));
-        this->errorPage_.push_back(errPage);
-    }
+    std::map<int, std::string> errPage;
+    errPage.insert(std::make_pair(PAGE_NUMBER, "404.html"));
+    this->errorPage_.push_back(errPage);
+}
 
 ServerContext::~ServerContext() {}
 
@@ -14,17 +14,17 @@ void ServerContext::setListen(u_int16_t port) { this->listen_ = port; }
 void ServerContext::setHost(const std::string& host) { this->host_ = host; }
 
 void ServerContext::setserverName(const std::string& serverName) {
-        this->serverName_ = serverName;
+    this->serverName_ = serverName;
 }
 
 void ServerContext::addMap(int number, const std::string& fileName) {
-        std::map<int, std::string> errPage;
-        errPage.insert(std::make_pair(number, fileName));
-        this->errorPage_.push_back(errPage);
+    std::map<int, std::string> errPage;
+    errPage.insert(std::make_pair(number, fileName));
+    this->errorPage_.push_back(errPage);
 }
 
 void ServerContext::setClientMaxBodySize(size_t size) {
-        this->clientMaxBodySize_ = size;
+    this->clientMaxBodySize_ = size;
 }
 
 const std::string& ServerContext::getValue() const { return (this->value_); }
@@ -33,21 +33,23 @@ u_int16_t ServerContext::getListen() const { return (this->listen_); }
 
 const std::string& ServerContext::getHost() const { return (this->host_); }
 
-const std::string& ServerContext::getserverName() const { return (this->serverName_); }
+const std::string& ServerContext::getserverName() const {
+    return (this->serverName_);
+}
 
 const std::vector<std::map<int, std::string> >& ServerContext::getErrorPage()
     const {
-        return (this->errorPage_);
+    return (this->errorPage_);
 }
 
 size_t ServerContext::getClientMaxBodySize() const {
-        return (this->clientMaxBodySize_);
+    return (this->clientMaxBodySize_);
 }
 
 std::vector<LocationContext>& ServerContext::getLocation() {
-        return (this->locations_);
+    return (this->locations_);
 }
 
 const std::vector<LocationContext>& ServerContext::getLocation() const {
-        return (this->locations_);
+    return (this->locations_);
 }

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -3,8 +3,8 @@
 #include <sys/types.h>
 
 #include <cstddef>
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 #include "config.hpp"
 #include "location.hpp"
@@ -36,7 +36,6 @@ void ConfigParser::makeVectorServer_() {
     for (size_t i = 0; i < this->tokens_.size(); ++i) {
         const TokenType type = this->tokens_[i].getType();
         const int lineNumber = this->tokens_[i].getLineNumber();
-
         if (type == BRACE) {
             updateDepth(tokens_[i], lineNumber);
             if (this->depth_ == 0) {
@@ -77,7 +76,10 @@ void ConfigParser::addServer_(size_t& index) {
     for (; index < this->tokens_.size(); ++(index)) {
         const int type = this->tokens_[index].getType();
         const int lineNum = this->tokens_[index].getLineNumber();
-        if (type == BRACE) {
+        if (type == SERVER) {
+            throwErr(tokens_[index].getText(), ": server in server error: line",
+                     lineNum);
+        } else if (type == BRACE) {
             updateDepth(this->tokens_[index], lineNum);
             if (this->depth_ == 0) {
                 break;
@@ -159,10 +161,13 @@ void ConfigParser::addLocation_(ServerContext& server, size_t& index) {
 
     location.setPath(path);
     for (; index < this->tokens_.size(); ++(index)) {
-        // const std::string text = this->tokens_[index].getText();
+        const std::string text = this->tokens_[index].getText();
         const int type = this->tokens_[index].getType();
         const int lineNum = this->tokens_[index].getLineNumber();
-        if (type == BRACE) {
+        if (type == SERVER || type == LOCATION) {
+            throwErr(text, ": server or location in location error: line",
+                     lineNum);
+        } else if (type == BRACE) {
             updateDepth(tokens_[index], lineNum);
             if (this->depth_ == 1) {
                 setDefaultMethod_(location);

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <stdexcept>
+#include <iostream>
 
 #include "config.hpp"
 #include "location.hpp"
@@ -15,7 +16,7 @@
 void (ConfigParser::* ConfigParser::funcServer_[FUNC_SERVER_SIZE])(
     ServerContext&, size_t&) = {
     &ConfigParser::setPort_,        &ConfigParser::setHost_,
-    &ConfigParser::setserverName_, &ConfigParser::setErrPage_,
+    &ConfigParser::setserverName_,  &ConfigParser::setErrPage_,
     &ConfigParser::setMaxBodySize_, &ConfigParser::addLocation_};
 
 void (ConfigParser::* ConfigParser::funcLocation_[FUNC_LOCATION_SIZE])(
@@ -26,288 +27,279 @@ void (ConfigParser::* ConfigParser::funcLocation_[FUNC_LOCATION_SIZE])(
 
 ConfigParser::ConfigParser(ConfigTokenizer& tokenizer)
     : tokens_(tokenizer.getTokens()), depth_(0) {
-        makeVectorServer_();
+    makeVectorServer_();
 }
 
 ConfigParser::~ConfigParser() {}
 
 void ConfigParser::makeVectorServer_() {
-        for (size_t i = 0; i < this->tokens_.size(); ++i) {
-                const TokenType type = this->tokens_[i].getType();
-                const std::string token = this->tokens_[i].getText();
-                const int lineNumber = this->tokens_[i].getLineNumber();
+    for (size_t i = 0; i < this->tokens_.size(); ++i) {
+        const TokenType type = this->tokens_[i].getType();
+        const int lineNumber = this->tokens_[i].getLineNumber();
 
-                if (type == BRACE) {
-                        updateDepth(token, lineNumber);
-                        if (this->depth_ == 0) {
-                                return;
-                        }
-                } else if (type == SERVER) {
-                        i++;
-                        if (i == this->tokens_.size()) {
-                                throwErr(this->tokens_[i].getText(),
-                                         ": Syntax error: line",
-                                         tokens_[i].getLineNumber());
-                        }
-                        addServer_(i);
-                } else {
-                        continue;
-                }
+        if (type == BRACE) {
+            updateDepth(tokens_[i], lineNumber);
+            if (this->depth_ == 0) {
+                return;
+            }
+        } else if (type == SERVER) {
+            i++;
+            if (this->depth_ != 0 || i == this->tokens_.size()) {
+                throwErr(this->tokens_[i].getText(), ": Syntax error: line",
+                         tokens_[i].getLineNumber());
+            }
+            addServer_(i);
+        } else {
+            continue;
         }
+    }
 }
 
-void ConfigParser::updateDepth(const std::string& token, int lineNumber) {
-        if (token == "{") {
-                this->depth_++;
-        } else if (token == "}") {
-                this->depth_--;
-                if (this->depth_ < 0) {
-                        throwErr(token, ": Config brace close error: line",
-                                 lineNumber);
-                }
+void ConfigParser::updateDepth(const Token& token, int lineNumber) {
+    const std::string text = token.getText();
+    if (text == "{" && token.getPosition() == BEGINNING) {
+        throwErr(text, ": Config brace close error: line", lineNumber);
+    }
+    if (text == "{") {
+        this->depth_++;
+    } else if (text == "}") {
+        this->depth_--;
+        if (this->depth_ < 0) {
+            throwErr(text, ": Config brace close error: line", lineNumber);
         }
+    }
 }
 
 void ConfigParser::addServer_(size_t& index) {
-        // NOLINTNEXTLINE(misc-const-correctness)
-        ServerContext server("server");
+    // NOLINTNEXTLINE(misc-const-correctness)
+    ServerContext server("server");
 
-        for (; index < this->tokens_.size(); ++(index)) {
-                const std::string text = this->tokens_[index].getText();
-                const int type = this->tokens_[index].getType();
-                const int lineNum = this->tokens_[index].getLineNumber();
-                if (type == BRACE) {
-                        updateDepth(text, lineNum);
-                        if (this->depth_ == 0) {
-                                break;
-                        }
-                } else if (type >= LISTEN && type <= LOCATION) {
-                        (this->*funcServer_[type])(server, index);
-                } else {
-                        continue;
-                }
+    for (; index < this->tokens_.size(); ++(index)) {
+        const int type = this->tokens_[index].getType();
+        const int lineNum = this->tokens_[index].getLineNumber();
+        if (type == BRACE) {
+            updateDepth(this->tokens_[index], lineNum);
+            if (this->depth_ == 0) {
+                break;
+            }
+        } else if (type >= LISTEN && type <= LOCATION) {
+            (this->*funcServer_[type])(server, index);
+        } else {
+            continue;
         }
-        this->servers_.push_back(server);
+    }
+    this->servers_.push_back(server);
 }
 
 void ConfigParser::setPort_(ServerContext& server, size_t& index) {
-        const std::string portNumber = incrementAndCheckSize_(index);
+    const std::string portNumber = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE &&
-            Validator::number(portNumber, LISTEN)) {
-                server.setListen(
-                    static_cast<u_int16_t>(atoi(portNumber.c_str())));
+    if (this->tokens_[index].getType() == VALUE &&
+        Validator::number(portNumber, LISTEN)) {
+        server.setListen(static_cast<u_int16_t>(atoi(portNumber.c_str())));
 
-        } else {
-                throwErr(portNumber, ": port value error: line",
-                         this->tokens_[index].getLineNumber());
-        }
+    } else {
+        throwErr(portNumber, ": port value error: line",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setHost_(ServerContext& server, size_t& index) {
-        const std::string hostName = incrementAndCheckSize_(index);
+    const std::string hostName = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE) {
-                server.setHost(hostName);
-        } else {
-                throwErr(hostName, ": Host value error: line",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE) {
+        server.setHost(hostName);
+    } else {
+        throwErr(hostName, ": Host value error: line",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setserverName_(ServerContext& server, size_t& index) {
-        const std::string serverName = incrementAndCheckSize_(index);
+    const std::string serverName = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE) {
-                server.setserverName(serverName);
-        } else {
-                throwErr(serverName, ": server_name value error: line",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE) {
+        server.setserverName(serverName);
+    } else {
+        throwErr(serverName, ": server_name value error: line",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setMaxBodySize_(ServerContext& server, size_t& index) {
-        const std::string maxBodySize = incrementAndCheckSize_(index);
+    const std::string maxBodySize = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE &&
-            Validator::number(maxBodySize, MAX_SIZE)) {
-                server.setClientMaxBodySize(
-                    static_cast<size_t>(atoi(maxBodySize.c_str())));
-        } else {
-                throwErr(maxBodySize, ": client_max_body_size error: line",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE &&
+        Validator::number(maxBodySize, MAX_SIZE)) {
+        server.setClientMaxBodySize(
+            static_cast<size_t>(atoi(maxBodySize.c_str())));
+    } else {
+        throwErr(maxBodySize, ": client_max_body_size error: line",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setErrPage_(ServerContext& server, size_t& index) {
-        const std::string errNumber = incrementAndCheckSize_(index);
+    const std::string errNumber = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE &&
-            Validator::number(errNumber, ERR_PAGE)) {
-                const std::string pageName = incrementAndCheckSize_(index);
-                server.addMap(atoi(errNumber.c_str()), pageName);
-        } else {
-                throwErr(errNumber, ": ErrorPage value error: line",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE &&
+        Validator::number(errNumber, ERR_PAGE)) {
+        const std::string pageName = incrementAndCheckSize_(index);
+        server.addMap(atoi(errNumber.c_str()), pageName);
+    } else {
+        throwErr(errNumber, ": ErrorPage value error: line",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::addLocation_(ServerContext& server, size_t& index) {
-        // NOLINTNEXTLINE(misc-const-correctness)
-        LocationContext location("location");
-        const std::string path = incrementAndCheckSize_(index);
+    // NOLINTNEXTLINE(misc-const-correctness)
+    LocationContext location("location");
+    const std::string path = incrementAndCheckSize_(index);
 
-        location.setPath(path);
-        for (; index < this->tokens_.size(); ++(index)) {
-                const std::string text = this->tokens_[index].getText();
-                const int type = this->tokens_[index].getType();
-                const int lineNum = this->tokens_[index].getLineNumber();
-                if (type == BRACE) {
-                        updateDepth(text, lineNum);
-                        if (this->depth_ == 1) {
-                                setDefaultMethod_(location);
-                                server.getLocation().push_back(location);
-                                break;
-                        }
-                } else if (type >= ROOT && type <= REDIRECT) {
-                        (this->*funcLocation_[type - FUNC_SERVER_SIZE])(
-                            location, index);
-                } else {
-                        continue;
-                }
+    location.setPath(path);
+    for (; index < this->tokens_.size(); ++(index)) {
+        // const std::string text = this->tokens_[index].getText();
+        const int type = this->tokens_[index].getType();
+        const int lineNum = this->tokens_[index].getLineNumber();
+        if (type == BRACE) {
+            updateDepth(tokens_[index], lineNum);
+            if (this->depth_ == 1) {
+                setDefaultMethod_(location);
+                server.getLocation().push_back(location);
+                break;
+            }
+        } else if (type >= ROOT && type <= REDIRECT) {
+            (this->*funcLocation_[type - FUNC_SERVER_SIZE])(location, index);
+        } else {
+            continue;
         }
+    }
 }
 
 void ConfigParser::setDefaultMethod_(LocationContext& location) {
-        OnOff* method = location.getMutableAllowedMethod();
-        if (method[GET] == OFF && method[POST] == OFF &&
-            method[DELETE] == OFF) {
-                location.setMethod(GET);
-                location.setMethod(POST);
-                location.setMethod(DELETE);
-        }
+    OnOff* method = location.getMutableAllowedMethod();
+    if (method[GET] == OFF && method[POST] == OFF && method[DELETE] == OFF) {
+        location.setMethod(GET);
+        location.setMethod(POST);
+        location.setMethod(DELETE);
+    }
 }
 
 void ConfigParser::setRoot_(LocationContext& location, size_t& index) {
-        const std::string root = incrementAndCheckSize_(index);
-        DocumentRootConfig& documentRootConfig =
-            location.getDocumentRootConfig();
+    const std::string root = incrementAndCheckSize_(index);
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
 
-        if (this->tokens_[index].getType() == VALUE) {
-                documentRootConfig.setRoot(root);
-        } else {
-                throwErr(this->tokens_[index].getText(),
-                         ": Root value error: line ",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE) {
+        documentRootConfig.setRoot(root);
+    } else {
+        throwErr(this->tokens_[index].getText(), ": Root value error: line ",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setMethod_(LocationContext& location, size_t& index) {
-        incrementAndCheckSize_(index);
+    incrementAndCheckSize_(index);
 
-        for (; index < this->tokens_.size(); ++index) {
-                const std::string method = this->tokens_[index].getText();
-                const TokenType type = this->tokens_[index].getType();
-                if (type == BRACE || (type >= ROOT && type <= REDIRECT)) {
-                        index--;
-                        return;
-                }
-                if (method == "GET" &&
-                    location.getMutableAllowedMethod()[GET] == OFF) {
-                        location.setMethod(GET);
-                } else if (method == "POST" &&
-                           location.getMutableAllowedMethod()[POST] == OFF) {
-                        location.setMethod(POST);
-                } else if (method == "DELETE" &&
-                           location.getMutableAllowedMethod()[DELETE] == OFF) {
-                        location.setMethod(DELETE);
-                } else {
-                        throwErr(method, ": Method value error: line ",
-                                 this->tokens_[index].getLineNumber());
-                }
+    for (; index < this->tokens_.size(); ++index) {
+        const std::string method = this->tokens_[index].getText();
+        const TokenType type = this->tokens_[index].getType();
+        if (type == BRACE || (type >= ROOT && type <= REDIRECT)) {
+            index--;
+            return;
         }
+        if (method == "GET" && location.getMutableAllowedMethod()[GET] == OFF) {
+            location.setMethod(GET);
+        } else if (method == "POST" &&
+                   location.getMutableAllowedMethod()[POST] == OFF) {
+            location.setMethod(POST);
+        } else if (method == "DELETE" &&
+                   location.getMutableAllowedMethod()[DELETE] == OFF) {
+            location.setMethod(DELETE);
+        } else {
+            throwErr(method, ": Method value error: line ",
+                     this->tokens_[index].getLineNumber());
+        }
+    }
 }
 
 void ConfigParser::setIndex_(LocationContext& location, size_t& index) {
-        const std::string indexPage = incrementAndCheckSize_(index);
+    const std::string indexPage = incrementAndCheckSize_(index);
 
-        DocumentRootConfig& documentRootConfig =
-            location.getDocumentRootConfig();
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
 
-        if (this->tokens_[index].getType() == VALUE) {
-                documentRootConfig.setIndex(indexPage);
-        } else {
-                throwErr(this->tokens_[index].getText(),
-                         ": Index page value error: line ",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE) {
+        documentRootConfig.setIndex(indexPage);
+    } else {
+        throwErr(this->tokens_[index].getText(),
+                 ": Index page value error: line ",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 void ConfigParser::setAutoIndex_(LocationContext& location, size_t& index) {
-        const std::string select = incrementAndCheckSize_(index);
-        DocumentRootConfig& documentRootConfig =
-            location.getDocumentRootConfig();
+    const std::string select = incrementAndCheckSize_(index);
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
 
-        if (this->tokens_[index].getType() == VALUE) {
-                if (select == "ON") {
-                        documentRootConfig.setAutoIndex(ON);
-                } else if (select == "OFF") {
-                        documentRootConfig.setAutoIndex(OFF);
-                } else {
-                        throwErr(select, ": Unknown select error: line ",
-                                 this->tokens_[index].getLineNumber());
-                }
+    if (this->tokens_[index].getType() == VALUE) {
+        if (select == "ON") {
+            documentRootConfig.setAutoIndex(ON);
+        } else if (select == "OFF") {
+            documentRootConfig.setAutoIndex(OFF);
+        } else {
+            throwErr(select, ": Unknown select error: line ",
+                     this->tokens_[index].getLineNumber());
         }
+    }
 }
 
 void ConfigParser::setIsCgi_(LocationContext& location, size_t& index) {
-        const std::string select = incrementAndCheckSize_(index);
-        DocumentRootConfig& documentRootConfig =
-            location.getDocumentRootConfig();
+    const std::string select = incrementAndCheckSize_(index);
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
 
-        if (this->tokens_[index].getType() == VALUE) {
-                if (select == "ON") {
-                        documentRootConfig.setCgiExtensions(ON);
-                } else if (select == "OFF") {
-                        documentRootConfig.setCgiExtensions(OFF);
-                } else {
-                        throwErr(select, ": Unknown select error: line ",
-                                 this->tokens_[index].getLineNumber());
-                }
+    if (this->tokens_[index].getType() == VALUE) {
+        if (select == "ON") {
+            documentRootConfig.setCgiExtensions(ON);
+        } else if (select == "OFF") {
+            documentRootConfig.setCgiExtensions(OFF);
+        } else {
+            throwErr(select, ": Unknown select error: line ",
+                     this->tokens_[index].getLineNumber());
         }
+    }
 }
 
 void ConfigParser::setRedirect_(LocationContext& location, size_t& index) {
-        const std::string redirect = incrementAndCheckSize_(index);
+    const std::string redirect = incrementAndCheckSize_(index);
 
-        if (this->tokens_[index].getType() == VALUE) {
-                location.setRedirect(redirect);
-        } else {
-                throwErr(this->tokens_[index].getText(),
-                         ": Redirect value error: line ",
-                         this->tokens_[index].getLineNumber());
-        }
+    if (this->tokens_[index].getType() == VALUE) {
+        location.setRedirect(redirect);
+    } else {
+        throwErr(this->tokens_[index].getText(),
+                 ": Redirect value error: line ",
+                 this->tokens_[index].getLineNumber());
+    }
 }
 
 std::string ConfigParser::incrementAndCheckSize_(size_t& index) {
-        index++;
-        if (index == this->tokens_.size()) {
-                throwErr("", "Syntax error: line",
-                         this->tokens_[index].getLineNumber());
-        }
-        return (this->tokens_[index].getText());
+    index++;
+    if (index == this->tokens_.size()) {
+        throwErr("", "Syntax error: line",
+                 this->tokens_[index].getLineNumber());
+    }
+    return (this->tokens_[index].getText());
 }
 
 std::vector<ServerContext>& ConfigParser::getServer() {
-        return (this->servers_);
+    return (this->servers_);
 }
 
 const std::vector<ServerContext>& ConfigParser::getServer() const {
-        return (this->servers_);
+    return (this->servers_);
 }
 
 void ConfigParser::throwErr(const std::string& str1, const std::string& str2,
                             int lineNumber) {
-        const std::string num = ConfigTokenizer::numberToStr(lineNumber);
-        throw(std::runtime_error(str1 + str2 + num));
+    const std::string num = ConfigTokenizer::numberToStr(lineNumber);
+    throw(std::runtime_error(str1 + str2 + num));
 }

--- a/src/config/testPrint.cpp
+++ b/src/config/testPrint.cpp
@@ -1,70 +1,62 @@
-#include "config/config.hpp"
-
 #include <cstddef>
 
+#include "config/config.hpp"
 #include "data.hpp"
 #include "document_root.hpp"
 #include "location.hpp"
 #include "server.hpp"
 
-
 void Config::printServer(const std::vector<ServerContext>& server) {
-        for (size_t i = 0; i < server.size(); ++i) {
-                std::cout << server[i].getValue() << std::endl;
-                std::cout << " |- listen: "
-                          << static_cast<int>(server[i].getListen())
-                          << std::endl;
-                std::cout << " |- host: " << server[i].getHost() << std::endl;
-                std::cout << " |- server_name: " << server[i].getserverName()
-                          << std::endl;
-                if (server[i].getClientMaxBodySize()) {
-                        std::cout << " |- client_max_body_size: "
-                                  << server[i].getClientMaxBodySize()
-                                  << std::endl;
-                }
-                const std::vector<std::map<int, std::string> >& errorPages =
-                    server[i].getErrorPage();
-                for (size_t j = 0; j < errorPages.size(); ++j) {
-                        const std::map<int, std::string>& pageMap =
-                            errorPages[j];
-                        for (std::map<int, std::string>::const_iterator it =
-                                 pageMap.begin();
-                             it != pageMap.end(); ++it) {
-                                std::cout << " |- error_page: " << it->first
-                                          << " -> " << it->second << std::endl;
-                        }
-                }
-                printLocation(server[i]);
-                std::cout << std::endl;
+    for (size_t i = 0; i < server.size(); ++i) {
+        std::cout << server[i].getValue() << std::endl;
+        std::cout << " |- listen: " << static_cast<int>(server[i].getListen())
+                  << std::endl;
+        std::cout << " |- host: " << server[i].getHost() << std::endl;
+        std::cout << " |- server_name: " << server[i].getserverName()
+                  << std::endl;
+        if (server[i].getClientMaxBodySize()) {
+            std::cout << " |- client_max_body_size: "
+                      << server[i].getClientMaxBodySize() << std::endl;
         }
+        const std::vector<std::map<int, std::string> >& errorPages =
+            server[i].getErrorPage();
+        for (size_t j = 0; j < errorPages.size(); ++j) {
+            const std::map<int, std::string>& pageMap = errorPages[j];
+            for (std::map<int, std::string>::const_iterator it =
+                     pageMap.begin();
+                 it != pageMap.end(); ++it) {
+                std::cout << " |- error_page: " << it->first << " -> "
+                          << it->second << std::endl;
+            }
+        }
+        printLocation(server[i]);
+        std::cout << std::endl;
+    }
 }
 
 void Config::printLocation(const ServerContext& server) {
-        const std::vector<LocationContext>& location = server.getLocation();
-        for (size_t k = 0; k < location.size(); ++k) {
-                const DocumentRootConfig& documentRootConfig =
-                    location[k].getDocumentRootConfig();
-                std::cout << " |- location: " << location[k].getPath()
-                          << std::endl;
-                if (!documentRootConfig.getRoot().empty()) {
-                        std::cout
-                            << "     |- root: " << documentRootConfig.getRoot()
-                            << std::endl;
-                }
-                const OnOff* method = location[k].getAllowedMethod();
-                std::cout << "     |- method: GET = " << method[GET]
-                          << " POST = " << method[POST]
-                          << " DELETE = " << method[DELETE] << std::endl;
-                std::cout << "     |- index: " << documentRootConfig.getIndex()
-                          << std::endl;
-                std::cout << "     |- auto_index: "
-                          << documentRootConfig.getAutoIndex() << std::endl;
-                std::cout << "     |- is_cgi: "
-                          << documentRootConfig.getCgiExtensions() << std::endl;
-                if (!location[k].getRedirect().empty()) {
-                        std::cout
-                            << "     |- redirect: " << location[k].getRedirect()
-                            << std::endl;
-                }
+    const std::vector<LocationContext>& location = server.getLocation();
+    for (size_t k = 0; k < location.size(); ++k) {
+        const DocumentRootConfig& documentRootConfig =
+            location[k].getDocumentRootConfig();
+        std::cout << " |- location: " << location[k].getPath() << std::endl;
+        if (!documentRootConfig.getRoot().empty()) {
+            std::cout << "     |- root: " << documentRootConfig.getRoot()
+                      << std::endl;
         }
+        const OnOff* method = location[k].getAllowedMethod();
+        std::cout << "     |- method: GET = " << method[GET]
+                  << " POST = " << method[POST]
+                  << " DELETE = " << method[DELETE] << std::endl;
+        std::cout << "     |- index: " << documentRootConfig.getIndex()
+                  << std::endl;
+        std::cout << "     |- auto_index: " << documentRootConfig.getAutoIndex()
+                  << std::endl;
+        std::cout << "     |- is_cgi: " << documentRootConfig.getCgiExtensions()
+                  << std::endl;
+        if (!location[k].getRedirect().empty()) {
+            std::cout << "     |- redirect: " << location[k].getRedirect()
+                      << std::endl;
+        }
+    }
 }

--- a/src/config/token.cpp
+++ b/src/config/token.cpp
@@ -1,8 +1,14 @@
 #include "config/token.hpp"
 
-Token::Token(const std::string& text, int lineNumber)
-    : text_(text), lineNumber_(lineNumber) {
-        setType_(text);
+#include <string>
+
+#include "parser.hpp"
+#include "tokenizer.hpp"
+
+Token::Token(const std::string& text, int lineNumber, TokenPosition position)
+    : text_(text), lineNumber_(lineNumber), position_(position) {
+    checkString_(text, lineNumber);
+    setType_(text);
 }
 
 Token::~Token() {}
@@ -13,33 +19,48 @@ int Token::getLineNumber() const { return (this->lineNumber_); }
 
 TokenType Token::getType() const { return (this->type_); }
 
-void Token::setType_(const std::string& text) {
-        static std::map<std::string, TokenType> tokenMap;
+TokenPosition Token::getPosition() const { return (this->position_); }
 
-        if (tokenMap.empty()) {
-                tokenMap.insert(std::make_pair("root", ROOT));
-                tokenMap.insert(std::make_pair("server", SERVER));
-                tokenMap.insert(std::make_pair("location", LOCATION));
-                tokenMap.insert(std::make_pair("location_back", LOCATION));
-                tokenMap.insert(std::make_pair("error_page", ERR_PAGE));
-                tokenMap.insert(std::make_pair("listen", LISTEN));
-                tokenMap.insert(std::make_pair("host", HOST));
-                tokenMap.insert(std::make_pair("server_names", SERVER_NAMES));
-                tokenMap.insert(std::make_pair("allow_method", METHOD));
-                tokenMap.insert(std::make_pair("index", INDEX));
-                tokenMap.insert(
-                    std::make_pair("client_max_body_size", MAX_SIZE));
-                tokenMap.insert(std::make_pair("autoindex", AUTOINDEX));
-                tokenMap.insert(std::make_pair("is_cgi", IS_CGI));
-                tokenMap.insert(std::make_pair("redirect", REDIRECT));
-                tokenMap.insert(std::make_pair("{", BRACE));
-                tokenMap.insert(std::make_pair("}", BRACE));
-        }
-        const std::map<std::string, TokenType>::const_iterator it =
-            tokenMap.find(text);
-        if (it != tokenMap.end()) {
-                this->type_ = it->second;
-        } else {
-                this->type_ = VALUE;
-        }
+void Token::checkString_(const std::string& text, int lineNumber) {
+    if (text.find('{') != std::string::npos && text.size() > 1) {
+        throw(std::runtime_error(text + ": Syntax error: " +
+                                 ConfigTokenizer::numberToStr(lineNumber)));
+    }
+    if (text.find('}') != std::string::npos && text.size() > 1) {
+        throw(std::runtime_error(text + ": Syntax error: " +
+                                 ConfigTokenizer::numberToStr(lineNumber)));
+    }
+}
+
+void Token::setType_(const std::string& text) {
+    static std::map<std::string, TokenType> tokenMap;
+    if (tokenMap.empty()) {
+        tokenMap.insert(std::make_pair("root", ROOT));
+        tokenMap.insert(std::make_pair("server", SERVER));
+        tokenMap.insert(std::make_pair("location", LOCATION));
+        tokenMap.insert(std::make_pair("location_back", LOCATION));
+        tokenMap.insert(std::make_pair("error_page", ERR_PAGE));
+        tokenMap.insert(std::make_pair("listen", LISTEN));
+        tokenMap.insert(std::make_pair("host", HOST));
+        tokenMap.insert(std::make_pair("server_names", SERVER_NAMES));
+        tokenMap.insert(std::make_pair("allow_method", METHOD));
+        tokenMap.insert(std::make_pair("index", INDEX));
+        tokenMap.insert(std::make_pair("client_max_body_size", MAX_SIZE));
+        tokenMap.insert(std::make_pair("autoindex", AUTOINDEX));
+        tokenMap.insert(std::make_pair("is_cgi", IS_CGI));
+        tokenMap.insert(std::make_pair("redirect", REDIRECT));
+    }
+    const std::map<std::string, TokenType>::const_iterator it =
+        tokenMap.find(text);
+    if (text == "{" || text == "}") {
+        this->type_ = BRACE;
+    } else if (this->position_ == BEGINNING && it != tokenMap.end()) {
+        this->type_ = it->second;
+    } else if (this->position_ == BEGINNING) {
+        throw(std::runtime_error(
+            text + ": Syntax error : line " +
+            ConfigTokenizer::numberToStr(this->lineNumber_)));
+    } else {
+        this->type_ = VALUE;
+    }
 }

--- a/src/config/tokenizer.cpp
+++ b/src/config/tokenizer.cpp
@@ -7,70 +7,70 @@
 // #include "gtest/gtest.h"
 
 ConfigTokenizer::ConfigTokenizer(std::string& filename) {
-        std::ifstream file(filename.c_str());
-        if (!file) {
-                throw(std::runtime_error("Failed to open file: " + filename));
-        }
-        makeTokenList_(file);
+    std::ifstream file(filename.c_str());
+    if (!file) {
+        throw(std::runtime_error("Failed to open file: " + filename));
+    }
+    makeTokenList_(file);
 }
 
 ConfigTokenizer::~ConfigTokenizer() {}
 
 const std::vector<Token>& ConfigTokenizer::getTokens() const {
-        return (this->tokens_);
+    return (this->tokens_);
 }
 
 void ConfigTokenizer::makeTokenList_(std::ifstream& file) {
-        std::string line;
-        int lineCount = 0;
-        while (std::getline(file, line)) {
-                std::istringstream iss(line);
-                std::string oneLine;
-                std::getline(iss, oneLine, '#');  // #以降を削除
-                oneLine.erase(0, oneLine.find_first_not_of(" \t"));
-                oneLine.erase(oneLine.find_last_not_of(" \t") + 1);
-                lineCount++;
-                checkLineEnd(oneLine, lineCount);
-                std::istringstream tokenStream(oneLine);
-                std::string token;
-                int stringCount = 0;
-                while (tokenStream >> token) {  // 空白区切りでtokenをset
-                        TokenPosition position = MIDDLE;
-                        if (token[token.size() - 1] == ';') {
-                                token = token.substr(0, token.size() - 1);
-                                position = END;
-                        }
-                        if (stringCount == 0) {
-                                position = BEGINNING;
-                        }
-                        Token newToken(token, lineCount, position);
-                        stringCount++;
-                        this->tokens_.push_back(newToken);
-                        tokenStream.clear();
-                }
+    std::string line;
+    int lineCount = 0;
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string oneLine;
+        std::getline(iss, oneLine, '#');  // #以降を削除
+        oneLine.erase(0, oneLine.find_first_not_of(" \t"));
+        oneLine.erase(oneLine.find_last_not_of(" \t") + 1);
+        lineCount++;
+        checkLineEnd(oneLine, lineCount);
+        std::istringstream tokenStream(oneLine);
+        std::string token;
+        int stringCount = 0;
+        while (tokenStream >> token) {  // 空白区切りでtokenをset
+            TokenPosition position = MIDDLE;
+            if (token[token.size() - 1] == ';') {
+                token = token.substr(0, token.size() - 1);
+                position = END;
+            }
+            if (stringCount == 0) {
+                position = BEGINNING;
+            }
+            Token newToken(token, lineCount, position);
+            stringCount++;
+            this->tokens_.push_back(newToken);
+            tokenStream.clear();
         }
-        file.close();
+    }
+    file.close();
 }
 
 void ConfigTokenizer::checkLineEnd(const std::string& line, int lineCount) {
-        if (line.empty()) {
-                return;
-        }
-        const char chara = line[line.size() - 1];
-        if (chara != '{' && chara != '}' && chara != ';') {
-                throw(std::runtime_error(
-                    line + ": Syntax error at the end of the line: line " +
-                    numberToStr(lineCount)));
-        }
-        if (line[0] == '}' && line.size() > 1) {
-                throw(std::runtime_error(line + ": Syntax error : line " +
-                                         numberToStr(lineCount)));
-        }
+    if (line.empty()) {
+        return;
+    }
+    const char chara = line[line.size() - 1];
+    if (chara != '{' && chara != '}' && chara != ';') {
+        throw(std::runtime_error(
+            line + ": Syntax error at the end of the line: line " +
+            numberToStr(lineCount)));
+    }
+    if (line[0] == '}' && line.size() > 1) {
+        throw(std::runtime_error(line + ": Syntax error : line " +
+                                 numberToStr(lineCount)));
+    }
 }
 
 std::string ConfigTokenizer::numberToStr(int number) {
-        std::stringstream ss;
-        ss << number;
-        const std::string str = ss.str();
-        return (str);
+    std::stringstream ss;
+    ss << number;
+    const std::string str = ss.str();
+    return (str);
 }

--- a/src/config/validator.cpp
+++ b/src/config/validator.cpp
@@ -5,29 +5,29 @@
 #include "token.hpp"
 
 bool Validator::number(const std::string& number, int type) {
-        for (size_t i = 0; i < number.size(); ++i) {
-                if (!isdigit(number[i])) {
-                        return (false);
-                }
+    for (size_t i = 0; i < number.size(); ++i) {
+        if (!isdigit(number[i])) {
+            return (false);
         }
+    }
 
-        const int num = atoi(number.c_str());
+    const int num = atoi(number.c_str());
 
-        if (type == LISTEN) {
-                return (num >= 0 && num <= MAX_PORT);
-        }
-        if (type == MAX_SIZE) {
-                return (num > 0 && num <= MAX_BODY_SIZE);
-        }
-        if (type == ERR_PAGE) {
-                return (num >= MIN_PAGE_NUM && num <= MAX_PAGE_NUM);
-        }
-        return (true);
+    if (type == LISTEN) {
+        return (num >= 0 && num <= MAX_PORT);
+    }
+    if (type == MAX_SIZE) {
+        return (num > 0 && num <= MAX_BODY_SIZE);
+    }
+    if (type == ERR_PAGE) {
+        return (num >= MIN_PAGE_NUM && num <= MAX_PAGE_NUM);
+    }
+    return (true);
 }
 
 bool Validator::url(const std::string& url) {
-        if (url.find("http://") != 0 && url.find("https://") != 0) {
-                return (false);
-        }
-        return (true);
+    if (url.find("http://") != 0 && url.find("https://") != 0) {
+        return (false);
+    }
+    return (true);
 }

--- a/test/config/parser_test.cpp
+++ b/test/config/parser_test.cpp
@@ -1,13 +1,16 @@
+#include "parser.hpp"
+
 #include <gtest/gtest.h>
+
 #include <fstream>
 #include <sstream>
-#include "parser.hpp"
-#include "tokenizer.hpp"
+
 #include "server.hpp"
 #include "token.hpp"
+#include "tokenizer.hpp"
 
 class ConfigParserTest : public ::testing::Test {
-protected:
+   protected:
     void SetUp() override {
         // Setup code here
     }
@@ -20,20 +23,23 @@ protected:
         }
     }
 
-    // Helper method to create a temporary config file and return ConfigTokenizer
-    std::unique_ptr<ConfigTokenizer> createTokenizerFromConfig(const std::string& configContent) {
+    // Helper method to create a temporary config file and return
+    // ConfigTokenizer
+    std::unique_ptr<ConfigTokenizer> createTokenizerFromConfig(
+        const std::string& configContent) {
         // Create a temporary file
-        std::string filename = "test_config_" + std::to_string(fileCounter_++) + ".conf";
+        std::string filename =
+            "test_config_" + std::to_string(fileCounter_++) + ".conf";
         tempFiles_.push_back(filename);
-        
+
         std::ofstream file(filename);
         file << configContent;
         file.close();
-        
-		return std::make_unique<ConfigTokenizer>(filename);
+
+        return std::make_unique<ConfigTokenizer>(filename);
     }
 
-private:
+   private:
     static int fileCounter_;
     std::vector<std::string> tempFiles_;
 };
@@ -43,12 +49,9 @@ int ConfigParserTest::fileCounter_ = 0;
 // Test constructor and destructor
 TEST_F(ConfigParserTest, ConstructorDestructorTest) {
     auto tokenizer = createTokenizerFromConfig("");
-    
-    EXPECT_NO_THROW({
-        ConfigParser parser(*tokenizer);
-    });
-}
 
+    EXPECT_NO_THROW({ ConfigParser parser(*tokenizer); });
+}
 
 // Test error page configuration
 TEST_F(ConfigParserTest, ParseErrorPageConfiguration) {
@@ -57,13 +60,14 @@ server {
     error_page 404 /error/404.html;
 }
 )";
-    
+
     auto tokenizer = createTokenizerFromConfig(config);
     ConfigParser parser(*tokenizer);
     const auto& servers = parser.getServer();
-    
+
     EXPECT_EQ(servers.size(), 1);
-    // Note: You'll need to add a getter method in ServerContext to test error pages
+    // Note: You'll need to add a getter method in ServerContext to test error
+    // pages
 }
 
 // Test max body size configuration
@@ -73,48 +77,28 @@ server {
     client_max_body_size 1024;
 }
 )";
-    
+
     auto tokenizer = createTokenizerFromConfig(config);
     ConfigParser parser(*tokenizer);
     const auto& servers = parser.getServer();
-    
+
     EXPECT_EQ(servers.size(), 1);
     EXPECT_EQ(servers[0].getClientMaxBodySize(), 1024);
 }
 
-// Test error handling - unmatched braces1
-TEST_F(ConfigParserTest, UnmatchedBracesError1) {
+// Test error handling - unmatched braces
+TEST_F(ConfigParserTest, UnmatchedBracesError) {
     std::string config = R"(
 server {
     listen 8080;
 }
 }
-)"; // Extra closing brace
-    
+)";  // Extra closing brace
+
     auto tokenizer = createTokenizerFromConfig(config);
-    
-    EXPECT_THROW({
-        ConfigParser parser(*tokenizer);
-    }, std::runtime_error);
+
+    EXPECT_THROW({ ConfigParser parser(*tokenizer); }, std::runtime_error);
 }
-
-// Test error handling - unmatched braces2
-TEST_F(ConfigParserTest, UnmatchedBracesError2) {
-    std::string config = R"(
-{ server {
-    listen 8080;
-}
-)"; // Extra closing brace
-    
-    auto tokenizer = createTokenizerFromConfig(config);
-    
-    EXPECT_THROW({
-        ConfigParser parser(*tokenizer);
-    }, std::runtime_error);
-}
-
-
-
 
 // Test error handling - invalid port number
 TEST_F(ConfigParserTest, InvalidPortNumberError) {
@@ -123,21 +107,18 @@ server {
     listen invalid_port;
 }
 )";
-    
-    auto tokenizer = createTokenizerFromConfig(config);
-    
-    EXPECT_THROW({
-        ConfigParser parser(*tokenizer);
-    }, std::runtime_error);
-}
 
+    auto tokenizer = createTokenizerFromConfig(config);
+
+    EXPECT_THROW({ ConfigParser parser(*tokenizer); }, std::runtime_error);
+}
 
 // Test static throwErr method
 TEST_F(ConfigParserTest, ThrowErrMethod) {
-    EXPECT_THROW({
-        ConfigParser::throwErr("test", " error: line ", 42);
-    }, std::runtime_error);
-    
+    EXPECT_THROW(
+        { ConfigParser::throwErr("test", " error: line ", 42); },
+        std::runtime_error);
+
     try {
         ConfigParser::throwErr("test", " error: line ", 42);
     } catch (const std::runtime_error& e) {
@@ -151,6 +132,6 @@ TEST_F(ConfigParserTest, EmptyConfiguration) {
     auto tokenizer = createTokenizerFromConfig("");
     ConfigParser parser(*tokenizer);
     const auto& servers = parser.getServer();
-    
+
     EXPECT_EQ(servers.size(), 0);
 }

--- a/test/config/parser_test.cpp
+++ b/test/config/parser_test.cpp
@@ -82,10 +82,8 @@ server {
     EXPECT_EQ(servers[0].getClientMaxBodySize(), 1024);
 }
 
-
-
-// Test error handling - unmatched braces
-TEST_F(ConfigParserTest, UnmatchedBracesError) {
+// Test error handling - unmatched braces1
+TEST_F(ConfigParserTest, UnmatchedBracesError1) {
     std::string config = R"(
 server {
     listen 8080;
@@ -99,6 +97,22 @@ server {
         ConfigParser parser(*tokenizer);
     }, std::runtime_error);
 }
+
+// Test error handling - unmatched braces2
+TEST_F(ConfigParserTest, UnmatchedBracesError2) {
+    std::string config = R"(
+{ server {
+    listen 8080;
+}
+)"; // Extra closing brace
+    
+    auto tokenizer = createTokenizerFromConfig(config);
+    
+    EXPECT_THROW({
+        ConfigParser parser(*tokenizer);
+    }, std::runtime_error);
+}
+
 
 
 


### PR DESCRIPTION
## 概要 / Overview

- config関連関数にエラーハンドリングを追加する

## 該当する issue

- #57 

## 変更内容

  - 以下のエラーハンドリングを実装した
 
    - server以外でファイルが始まる
```
configParser.cpp line 46~49   [this0>depth_ != 0]を条件に加えた
            if (this->depth_ != 0 || i == this->tokens_.size()) {
                throwErr(this->tokens_[i].getText(), ": Syntax error: line",
                         tokens_[i].getLineNumber());
            }
```
    - server ブロック中にserverが存在する
```
configPaser.cpp line 79~82
        if (type == SERVER) {
            throwErr(tokens_[index].getText(), ": server in server error: line",
                     lineNum);
```

    - locationブロック中にserver/locationブロックが存在する
```
configParser.cpp line 167~169
          if (type == SERVER || type == LOCATION) {
            throwErr(text, ": server or location in location error: line",
                     lineNum);
```

    - 行の先頭に'{'が位置する
```
configParser.cpp line 59~61
    if (text == "{" && token.getPosition() == BEGINNING) {
        throwErr(text, ": Config brace close error: line", lineNumber);
    }
```

    -  '{','}'が１文字でない
```
Token.cpp line 24~33
void Token::checkString_(const std::string& text, int lineNumber) {
    if (text.find('{') != std::string::npos && text.size() > 1) {
        throw(std::runtime_error(text + ": Syntax error: " +
                                 ConfigTokenizer::numberToStr(lineNumber)));
    }
    if (text.find('}') != std::string::npos && text.size() > 1) {
        throw(std::runtime_error(text + ": Syntax error: " +
                                 ConfigTokenizer::numberToStr(lineNumber)));
    }
}
```

    - 扱わないメンバ変数が存在する
```
Token.cpp line 57~62 先頭の文字列に対して文字列の判定をするように変更した
    } else if (this->position_ == BEGINNING && it != tokenMap.end()) {
        this->type_ = it->second;
    } else if (this->position_ == BEGINNING) {
        throw(std::runtime_error(
            text + ": Syntax error : line " +
            ConfigTokenizer::numberToStr(this->lineNumber_)));
```
 

- 変更後

上記エラーハンドリングを実装した

- 変更点
  - Token class にenum TokenPosition {BEGINNING, MIDDLE, END};とTokenPosition position_;を作り、文字列のどの位置にtokenが位置するかという情報を持たせた
  - 各行の先頭文字列のエラー判定にposition_を使った
```
Tokenizer.cpp line 36~47 stringCountを使って文字列のpositionを求めて、tokenにposition情報を持たせた
        int stringCount = 0;
        while (tokenStream >> token) {  // 空白区切りでtokenをset
            TokenPosition position = MIDDLE;
            if (token[token.size() - 1] == ';') {
                token = token.substr(0, token.size() - 1);
                position = END;
            }
            if (stringCount == 0) {
                position = BEGINNING;
            }
            Token newToken(token, lineCount, position);
            stringCount++;
```

## 影響範囲
- config/以下、特にToken, configTokenizer, configParser class
- 

## その他
以下はエラーとした
- listen 80 ; (セミコロンの前に空白がある）

config関連ファイルは新しいフォーマットに対応させました
