### PR TITLE
26 feat read request header

### DIFF
--- a/include/http/request/read/header.hpp
+++ b/include/http/request/read/header.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "state.hpp"
 #include "buffer.hpp"
+#include "state.hpp"
 
 // class ReadBuffer;
 
@@ -11,8 +11,9 @@ class ReadingRequestHeadersState : public IState {
     ReadingRequestHeadersState();
     virtual ~ReadingRequestHeadersState();
     TransitionResult handle(ReadBuffer& buf);
+
    private:
-	std::vector<std::string> headerLine_;
+    std::vector<std::string> headerLine_;
 };
-    
-} // namespace http
+
+}  // namespace http

--- a/include/http/request/read/header.hpp
+++ b/include/http/request/read/header.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "state.hpp"
+#include "buffer.hpp"
+
+// class ReadBuffer;
+
+namespace http {
+
+class ReadingRequestHeadersState : public IState {
+   public:
+    ReadingRequestHeadersState();
+    virtual ~ReadingRequestHeadersState();
+    TransitionResult handle(ReadBuffer& buf);
+   private:
+	std::vector<std::string> headerLine_;
+};
+    
+} // namespace http

--- a/include/http/request/read/header.hpp
+++ b/include/http/request/read/header.hpp
@@ -11,9 +11,6 @@ class ReadingRequestHeadersState : public IState {
     ReadingRequestHeadersState();
     virtual ~ReadingRequestHeadersState();
     TransitionResult handle(ReadBuffer& buf);
-
-   private:
-    std::vector<std::string> headerLine_;
 };
 
 }  // namespace http

--- a/src/http/request/read/header.cpp
+++ b/src/http/request/read/header.cpp
@@ -2,18 +2,18 @@
 #include "raw_headers.hpp"
 #include "state.hpp"
 #include "utils.hpp"
-#include "utils/types/try.hpp"
+//#include "utils/types/try.hpp"
 #include "utils/types/result.hpp"
 #include "utils/types/option.hpp"
 #include "utils/types/error.hpp"
-#include "line.hpp"
+//#include "line.hpp"
 
 namespace http {
 
-ReadingHeadersState::ReadingHeadersState() {}
-ReadingHeadersState::~ReadingHeadersState() {}
+ReadingRequestHeadersState::ReadingRequestHeadersState() {}
+ReadingRequestHeadersState::~ReadingRequestHeadersState() {}
 
-TransitionResult ReadingHeadersState::handle(ReadBuffer& buf) {
+TransitionResult ReadingRequestHeadersState::handle(ReadBuffer& buf) {
 	TransitionResult tr;
 	RawHeaders headers;
 
@@ -23,21 +23,26 @@ TransitionResult ReadingHeadersState::handle(ReadBuffer& buf) {
 			tr.setStatus(types::err(result.unwrapErr()));
 			return tr;
 		}
-
 		const types::Option<std::string> lineOpt = result.unwrap();
 		if (lineOpt.isNone()) {
-			tr.setStatus(ok(kSuspend));
+			tr.setStatus(types::ok(kSuspend));
 			return tr;
 		}
-
 		const std::string line = lineOpt.unwrap();
 		if (line.empty()) {
-			tr.setHeaders(some(headers));
-			tr.setStatus(ok(kDone));
+			tr.setHeaders(types::some(headers));
+			tr.setStatus(types::ok(kDone));
 			return tr;
 		}
-		
+		const std::string::size_type colon = line.find(':');
+		if (colon == std::string::npos) {
+			tr.setStatus(types::err(error::kIOUnknown));
+			return tr;
+		}
+		const std::string key = line.substr(0, colon);
+		const std::string value = line.substr(colon + 1);
+		headers.insert(std::make_pair(key, value));
 	}
 }
 
-}
+} // namespace http

--- a/src/http/request/read/header.cpp
+++ b/src/http/request/read/header.cpp
@@ -1,12 +1,11 @@
 #include "header.hpp"
+
 #include "raw_headers.hpp"
 #include "state.hpp"
 #include "utils.hpp"
-//#include "utils/types/try.hpp"
-#include "utils/types/result.hpp"
-#include "utils/types/option.hpp"
 #include "utils/types/error.hpp"
-//#include "line.hpp"
+#include "utils/types/option.hpp"
+#include "utils/types/result.hpp"
 
 namespace http {
 
@@ -14,35 +13,35 @@ ReadingRequestHeadersState::ReadingRequestHeadersState() {}
 ReadingRequestHeadersState::~ReadingRequestHeadersState() {}
 
 TransitionResult ReadingRequestHeadersState::handle(ReadBuffer& buf) {
-	TransitionResult tr;
-	RawHeaders headers;
+    TransitionResult tr;
+    RawHeaders headers;
 
-	while (true) {
-		const GetLineResult result = getLine(buf);
-		if (!result.canUnwrap()) {
-			tr.setStatus(types::err(result.unwrapErr()));
-			return tr;
-		}
-		const types::Option<std::string> lineOpt = result.unwrap();
-		if (lineOpt.isNone()) {
-			tr.setStatus(types::ok(kSuspend));
-			return tr;
-		}
-		const std::string line = lineOpt.unwrap();
-		if (line.empty()) {
-			tr.setHeaders(types::some(headers));
-			tr.setStatus(types::ok(kDone));
-			return tr;
-		}
-		const std::string::size_type colon = line.find(':');
-		if (colon == std::string::npos) {
-			tr.setStatus(types::err(error::kIOUnknown));
-			return tr;
-		}
-		const std::string key = line.substr(0, colon);
-		const std::string value = line.substr(colon + 1);
-		headers.insert(std::make_pair(key, value));
-	}
+    while (true) {
+        const GetLineResult result = getLine(buf);
+        if (!result.canUnwrap()) {
+            tr.setStatus(types::err(result.unwrapErr()));
+            return tr;
+        }
+        const types::Option<std::string> lineOpt = result.unwrap();
+        if (lineOpt.isNone()) {
+            tr.setStatus(types::ok(kSuspend));
+            return tr;
+        }
+        const std::string line = lineOpt.unwrap();
+        if (line.empty()) {
+            tr.setHeaders(types::some(headers));
+            tr.setStatus(types::ok(kDone));
+            return tr;
+        }
+        const std::string::size_type colon = line.find(':');
+        if (colon == std::string::npos) {
+            tr.setStatus(types::err(error::kIOUnknown));
+            return tr;
+        }
+        const std::string key = line.substr(0, colon);
+        const std::string value = line.substr(colon + 1);
+        headers.insert(std::make_pair(key, value));
+    }
 }
 
-} // namespace http
+}  // namespace http

--- a/src/http/request/read/header.cpp
+++ b/src/http/request/read/header.cpp
@@ -1,0 +1,43 @@
+#include "header.hpp"
+#include "raw_headers.hpp"
+#include "state.hpp"
+#include "utils.hpp"
+#include "utils/types/try.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/option.hpp"
+#include "utils/types/error.hpp"
+#include "line.hpp"
+
+namespace http {
+
+ReadingHeadersState::ReadingHeadersState() {}
+ReadingHeadersState::~ReadingHeadersState() {}
+
+TransitionResult ReadingHeadersState::handle(ReadBuffer& buf) {
+	TransitionResult tr;
+	RawHeaders headers;
+
+	while (true) {
+		const GetLineResult result = getLine(buf);
+		if (!result.canUnwrap()) {
+			tr.setStatus(types::err(result.unwrapErr()));
+			return tr;
+		}
+
+		const types::Option<std::string> lineOpt = result.unwrap();
+		if (lineOpt.isNone()) {
+			tr.setStatus(ok(kSuspend));
+			return tr;
+		}
+
+		const std::string line = lineOpt.unwrap();
+		if (line.empty()) {
+			tr.setHeaders(some(headers));
+			tr.setStatus(ok(kDone));
+			return tr;
+		}
+		
+	}
+}
+
+}

--- a/src/http/request/read/line.cpp
+++ b/src/http/request/read/line.cpp
@@ -44,7 +44,7 @@ TransitionResult ReadingRequestLineState::handle(ReadBuffer& buf) {
   }
 
   tr.setRequestLine(types::Option<std::string>(types::some(line)));
-  // tr.setNextState(new ReadingHeadersState());
+  tr.setNextState(new ReadingRequestHeadersState());
   tr.setStatus(types::ok(IState::kDone));
   return tr;
 }

--- a/src/http/request/read/line.cpp
+++ b/src/http/request/read/line.cpp
@@ -5,6 +5,7 @@
 #include "utils/types/result.hpp"
 #include "utils/types/option.hpp"
 #include "utils/types/error.hpp"
+#include "http/request/read/header.hpp"
 
 namespace http {
 

--- a/test/http/request/read/CMakeLists.txt
+++ b/test/http/request/read/CMakeLists.txt
@@ -31,8 +31,16 @@ target_link_libraries(context_test
     PRIVATE webserv_lib gtest
 )
 
+add_executable(header_test header_test.cpp)
+target_link_libraries(header_test
+    PRIVATE webserv_lib gtest
+)
+gtest_discover_tests(header_test)
+
+
 include(GoogleTest)
 gtest_discover_tests(getline_test)
 gtest_discover_tests(reader_test)
 gtest_discover_tests(line_test)
 gtest_discover_tests(context_test)
+gtest_discover_tests(header_test) 

--- a/test/http/request/read/CMakeLists.txt
+++ b/test/http/request/read/CMakeLists.txt
@@ -35,8 +35,6 @@ add_executable(header_test header_test.cpp)
 target_link_libraries(header_test
     PRIVATE webserv_lib gtest
 )
-gtest_discover_tests(header_test)
-
 
 include(GoogleTest)
 gtest_discover_tests(getline_test)

--- a/test/http/request/read/header_test.cpp
+++ b/test/http/request/read/header_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <cstring>
+#include "io/input/read/buffer.hpp"
+#include "io/input/reader/reader.hpp"
+#include "http/request/read/header.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/option.hpp"
+#include "utils/types/error.hpp"
+
+namespace {
+
+class DummyReader : public io::IReader {
+public:
+    explicit DummyReader(const std::string& input)
+        : inputData_(input), position_(0) {}
+
+    virtual types::Result<std::size_t, error::AppError> read(char* destination, std::size_t byteCount) {
+        if (position_ >= inputData_.size()) {
+            return types::ok(0ul);
+        }
+        std::size_t copyLength = std::min(byteCount, inputData_.size() - position_);
+        memcpy(destination, inputData_.data() + position_, copyLength);
+        position_ += copyLength;
+        return types::ok(copyLength);
+    }
+
+    virtual bool eof() {
+        return position_ >= inputData_.size();
+    }
+
+private:
+    std::string inputData_;
+    std::size_t position_;
+};
+
+}  // namespace
+
+TEST(ReadingRequestHeadersStateTest, EmptyBufferReturnsSuspend) {
+    DummyReader dummyReader("");
+    ReadBuffer readBuffer(dummyReader);
+    http::ReadingRequestHeadersState state;
+
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isOk());
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+    EXPECT_TRUE(result.getHeaders().isNone());
+}
+
+TEST(ReadingRequestHeadersStateTest, InvalidHeaderReturnsError) {
+    DummyReader dummyReader("InvalidHeader\r\n\r\n");
+    ReadBuffer readBuffer(dummyReader);
+    http::ReadingRequestHeadersState state;
+
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isErr());
+    EXPECT_EQ(result.getStatus().unwrapErr(), error::kIOUnknown);
+    EXPECT_TRUE(result.getHeaders().isNone());
+}
+
+TEST(ReadingRequestHeadersStateTest, ValidHeadersReturnsDone) {
+    DummyReader dummyReader("Host: localhost\r\nUser-Agent: curl\r\n\r\n");
+    ReadBuffer readBuffer(dummyReader);
+    http::ReadingRequestHeadersState state;
+
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isOk());
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kDone);
+
+    ASSERT_TRUE(result.getHeaders().isSome());
+    const RawHeaders& headers = result.getHeaders().unwrap();
+
+    ASSERT_EQ(headers.size(), 2);
+    EXPECT_EQ(headers.find("Host")->second, " localhost");
+    EXPECT_EQ(headers.find("User-Agent")->second, " curl");
+}
+
+TEST(ReadingRequestHeadersStateTest, HeaderWithoutColonReturnsError) {
+    DummyReader dummyReader("Host localhost\r\n\r\n");
+    ReadBuffer readBuffer(dummyReader);
+    http::ReadingRequestHeadersState state;
+
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isErr());
+    EXPECT_TRUE(result.getHeaders().isNone());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 概要 / Overview

- ReadingRequestHeadersStateクラスの作成

## 該当する issue

- #26 

## 変更内容

src/http/request/read/下にheader.cppを作った
ReadingRequestHeadersStateクラスでは、読み込んだヘッダーを
・vectorに収納する
・vectorのstringを、':'でkey->valueに分けてRawHeaders headersにinsertする
・headersをTrasitionResult trにsetしtrをreturnする

## 影響範囲
- http/request/read  header.hpp, header.cpp, line.cpp(line 47)
- test/http/request/read CMakeLists.txt, header_test.cpp

## その他
class図
https://www.mermaidchart.com/app/projects/bd2f6b3f-41b2-4fc5-96bb-376f929f5a64/diagrams/51b10931-9237-4149-9b30-64cb3bad032d/share/invite/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2N1bWVudElEIjoiNTFiMTA5MzEtOTIzNy00MTQ5LTliMzAtNjRjYjNiYWQwMzJkIiwiYWNjZXNzIjoiRWRpdCIsImlhdCI6MTc1MjM4NDMwMX0.5fYms-HXzJX15J1t8Ih-RjaEbK4bzHmpvmRZvHUMiH8