### PR TITLE
90 feat read request body length

### DIFF
--- a/include/http/request/read/length_body.hpp
+++ b/include/http/request/read/length_body.hpp
@@ -4,14 +4,15 @@
 #include "state.hpp"
 
 namespace http {
-	class ReadingRequestBodyLengthState : public IState {
-	   public:
-		explicit ReadingRequestBodyLengthState(std::size_t contentLength);
-		virtual ~ReadingRequestBodyLengthState();
-		virtual TransitionResult handle(ReadBuffer& buf);
-	   private:
-		std::size_t contentLength_;
-		std::size_t alreadyRead_;
-		std::string bodyBuffer_;	
-	};
-}	// namespace http
+class ReadingRequestBodyLengthState : public IState {
+   public:
+    explicit ReadingRequestBodyLengthState(std::size_t contentLength);
+    virtual ~ReadingRequestBodyLengthState();
+    virtual TransitionResult handle(ReadBuffer& buf);
+
+   private:
+    size_t contentLength_;
+    size_t alreadyRead_;
+    std::string bodyBuffer_;
+};
+}  // namespace http

--- a/include/http/request/read/length_body.hpp
+++ b/include/http/request/read/length_body.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "buffer.hpp"
+#include "state.hpp"
+
+namespace http {
+	class ReadingRequestBodyLengthState : public IState {
+	   public:
+		explicit ReadingRequestBodyLengthState(std::size_t contentLength);
+		virtual ~ReadingRequestBodyLengthState();
+		virtual TransitionResult handle(ReadBuffer& buf);
+	   private:
+		std::size_t contentLength_;
+		std::size_t alreadyRead_;
+		std::string bodyBuffer_;	
+	};
+}	// namespace http

--- a/include/io/input/read/buffer.hpp
+++ b/include/io/input/read/buffer.hpp
@@ -18,6 +18,7 @@ public:
 
     typedef types::Result<std::size_t, error::AppError> LoadResult;
     LoadResult load();
+	size_t size() const;
 
 private:
     std::vector<char> buf_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(webserv_lib STATIC
     server/socket/serverSocket.cpp
     server/socket/socketAddr.cpp
     http/request/read/body.cpp
+    http/request/read/length_body.cpp
     http/request/read/chunked_body.cpp
     http/request/read/context.cpp
     http/request/read/header.cpp

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -1,38 +1,40 @@
 #include "length_body.hpp"
+
 #include "state.hpp"
-#include "utils/types/result.hpp"
 #include "utils/types/option.hpp"
+#include "utils/types/result.hpp"
 
 namespace http {
 
-ReadingRequestBodyLengthState::ReadingRequestBodyLengthState(std::size_t contentLength)
-	: contentLength_(contentLength), alreadyRead_(0) {}
+ReadingRequestBodyLengthState::ReadingRequestBodyLengthState(
+    std::size_t contentLength)
+    : contentLength_(contentLength), alreadyRead_(0) {}
 
 ReadingRequestBodyLengthState::~ReadingRequestBodyLengthState() {}
 
 // Content-Lengthで指定されたbodyサイズ分だけbufから読み取りためておく
 // 全部読み取れないなどのエラーはソケット側でタイムアウト処理をするのでここでは感知しない
 TransitionResult ReadingRequestBodyLengthState::handle(ReadBuffer& buf) {
-	TransitionResult tr;
-	std::size_t remain = contentLength_ - alreadyRead_;
-	std::size_t toRoad = std::min(remain, buf.size());
+    TransitionResult tr;
+    const size_t remain = contentLength_ - alreadyRead_;
+    const size_t toRoad = std::min(remain, buf.size());
 
-	if (toRoad == 0) {
-		tr.setStatus(types::ok(IState::kSuspend)); // データ待ち
-		return tr;
-	}
+    if (toRoad == 0) {
+        tr.setStatus(types::ok(IState::kSuspend));  // データ待ち
+        return tr;
+    }
 
-	std::string segment = buf.consume(toRoad); // 読み取って消費
-	bodyBuffer_ += segment;
-	alreadyRead_ += segment.size();
+    const std::string segment = buf.consume(toRoad);  // 読み取って消費
+    bodyBuffer_ += segment;
+    alreadyRead_ += segment.size();
 
-	if (alreadyRead_ >= contentLength_) {
-		tr.setBody(types::some(bodyBuffer_));
-		tr.setStatus(types::ok(IState::kDone));
-	} else {
-		tr.setStatus(types::ok(IState::kSuspend));
-	}
+    if (alreadyRead_ >= contentLength_) {
+        tr.setBody(types::some(bodyBuffer_));
+        tr.setStatus(types::ok(IState::kDone));
+    } else {
+        tr.setStatus(types::ok(IState::kSuspend));
+    }
 
-	return tr;
+    return tr;
 }
-} // namespace http
+}  // namespace http

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -1,0 +1,38 @@
+#include "length_body.hpp"
+#include "state.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/option.hpp"
+
+namespace http {
+
+ReadingRequestBodyLengthState::ReadingRequestBodyLengthState(std::size_t contentLength)
+	: contentLength_(contentLength), alreadyRead_(0) {}
+
+ReadingRequestBodyLengthState::~ReadingRequestBodyLengthState() {}
+
+// Content-Lengthで指定されたbodyサイズ分だけbufから読み取りためておく
+// 全部読み取れないなどのエラーはソケット側でタイムアウト処理をするのでここでは感知しない
+TransitionResult ReadingRequestBodyLengthState::handle(ReadBuffer& buf) {
+	TransitionResult tr;
+	std::size_t remain = contentLength_ - alreadyRead_;
+	std::size_t toRoad = std::min(remain, buf.size());
+
+	if (toRoad == 0) {
+		tr.setStatus(types::ok(IState::kSuspend)); // データ待ち
+		return tr;
+	}
+
+	std::string segment = buf.consume(toRoad); // 読み取って消費
+	bodyBuffer_ += segment;
+	alreadyRead_ += segment.size();
+
+	if (alreadyRead_ >= contentLength_) {
+		tr.setBody(types::some(bodyBuffer_));
+		tr.setStatus(types::ok(IState::kDone));
+	} else {
+		tr.setStatus(types::ok(IState::kSuspend));
+	}
+
+	return tr;
+}
+} // namespace http

--- a/src/io/input/read/buffer.cpp
+++ b/src/io/input/read/buffer.cpp
@@ -63,6 +63,9 @@ ReadBuffer::LoadResult ReadBuffer::load() {
     return OK(bytesRead);
 }
 
+size_t ReadBuffer::size() const {
+    return buf_.size();
+}
 // 低レベルなリーダーIReaderからバッファ付きで文字列を読み取るラッパー
 // ・ReadBufferはIReader(例えばFdReader)のラッパー
 // ・内部にstd::vector<char> buf_を持ち、読み込み済みのデータを一時保持する

--- a/test/http/request/read/CMakeLists.txt
+++ b/test/http/request/read/CMakeLists.txt
@@ -36,9 +36,14 @@ target_link_libraries(header_test
     PRIVATE webserv_lib gtest
 )
 
+add_executable(body_length_test body_length_test.cpp)
+target_link_libraries(body_length_test
+    PRIVATE webserv_lib gtest)
+
 include(GoogleTest)
 gtest_discover_tests(getline_test)
 gtest_discover_tests(reader_test)
 gtest_discover_tests(line_test)
 gtest_discover_tests(context_test)
 gtest_discover_tests(header_test) 
+gtest_discover_tests(body_length_test)

--- a/test/http/request/read/body_length_test.cpp
+++ b/test/http/request/read/body_length_test.cpp
@@ -1,0 +1,173 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <cstring>
+
+#include "http/request/read/length_body.hpp"
+#include "io/input/read/buffer.hpp"
+#include "io/input/reader/reader.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/option.hpp"
+#include "utils/types/error.hpp"
+
+namespace {
+
+// 普通のメモリベースReader
+class DummyReader : public io::IReader {
+public:
+    explicit DummyReader(const std::string& input)
+        : inputData_(input), position_(0) {}
+
+    types::Result<std::size_t, error::AppError> read(char* dest, std::size_t nbyte) {
+        if (position_ >= inputData_.size()) {
+            return types::ok(0ul);
+        }
+        const std::size_t copyLen = std::min(nbyte, inputData_.size() - position_);
+        memcpy(dest, inputData_.data() + position_, copyLen);
+        position_ += copyLen;
+        return types::ok(copyLen);
+    }
+
+    bool eof() {
+        return position_ >= inputData_.size();
+    }
+
+private:
+    std::string inputData_;
+    std::size_t position_;
+};
+
+// 2段階でデータを返すReader（"He", "llo"）
+class MultiStageReader : public io::IReader {
+public:
+    MultiStageReader() : stage_(0), position_(0) {}
+
+    types::Result<std::size_t, error::AppError> read(char* dest, std::size_t nbyte) {
+        const std::vector<std::string> stages = { "He", "llo" };
+        if (stage_ >= stages.size()) {
+            return types::ok(0ul);
+        }
+
+        const std::string& current = stages[stage_];
+        std::size_t copyLen = std::min(nbyte, current.size() - position_);
+        memcpy(dest, current.data() + position_, copyLen);
+        position_ += copyLen;
+
+        if (position_ >= current.size()) {
+            stage_++;
+            position_ = 0;
+        }
+
+        return types::ok(copyLen);
+    }
+
+    bool eof() {
+        return stage_ >= 2;
+    }
+
+private:
+    std::size_t stage_;
+    std::size_t position_;
+};
+
+// 読み込み失敗を強制するReader
+class FailingReader : public io::IReader {
+public:
+    types::Result<std::size_t, error::AppError> read(char*, std::size_t) {
+        return types::err(error::kIOUnknown);
+    }
+
+    bool eof() {
+        return false;
+    }
+};
+
+}  // namespace
+
+// ====== テスト本体 ======
+
+TEST(ReadingRequestBodyLengthStateTest, ReturnsSuspendWhenNoDataAvailable) {
+    DummyReader dummyReader("");
+    ReadBuffer readBuffer(dummyReader);
+    http::ReadingRequestBodyLengthState state(5);
+
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isOk());
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+    EXPECT_TRUE(result.getBody().isNone());
+}
+
+TEST(ReadingRequestBodyLengthStateTest, ReturnsSuspendIfPartialDataAvailable) {
+    DummyReader dummyReader("He");
+    ReadBuffer readBuffer(dummyReader);
+    readBuffer.load();
+
+    http::ReadingRequestBodyLengthState state(5);
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isOk());
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+    EXPECT_TRUE(result.getBody().isNone());
+}
+
+TEST(ReadingRequestBodyLengthStateTest, ReturnsDoneWhenEnoughDataAvailable) {
+    DummyReader dummyReader("Hello");
+    ReadBuffer readBuffer(dummyReader);
+    readBuffer.load();
+
+    http::ReadingRequestBodyLengthState state(5);
+    http::TransitionResult result = state.handle(readBuffer);
+
+    ASSERT_TRUE(result.getStatus().isOk());
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kDone);
+    ASSERT_TRUE(result.getBody().isSome());
+    EXPECT_EQ(result.getBody().unwrap(), "Hello");
+}
+
+TEST(ReadingRequestBodyLengthStateTest, HandlesMultiplePartialLoads) {
+    MultiStageReader multiReader;
+    ReadBuffer readBuffer(multiReader);
+    http::ReadingRequestBodyLengthState state(5);
+
+    readBuffer.load();  // "He"
+    http::TransitionResult result = state.handle(readBuffer);
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    readBuffer.load();  // "llo"
+    result = state.handle(readBuffer);
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kDone);
+    ASSERT_TRUE(result.getBody().isSome());
+    EXPECT_EQ(result.getBody().unwrap(), "Hello");
+}
+
+TEST(ReadingRequestBodyLengthStateTest, ReturnsErrorOnReadFailure) {
+    FailingReader failingReader;
+    ReadBuffer readBuffer(failingReader);
+    http::ReadingRequestBodyLengthState state(5);
+
+    auto result = readBuffer.load();
+    ASSERT_TRUE(result.isErr());
+
+    http::TransitionResult transitionResult = state.handle(readBuffer);
+    ASSERT_TRUE(transitionResult.getStatus().isOk());
+    EXPECT_EQ(transitionResult.getStatus().unwrap(), http::IState::kSuspend);
+    EXPECT_TRUE(transitionResult.getBody().isNone());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+
+// 既存のテストに続けてこれを追加
+class FailingReader : public io::IReader {
+public:
+    virtual types::Result<std::size_t, error::AppError> read(char*, std::size_t) {
+        return types::err(error::kIOUnknown);  // 読み取り失敗を意図的に発生
+    }
+
+    virtual bool eof() {
+        return false;
+    }
+};


### PR DESCRIPTION
## 概要 / Overview

- ReadingRequestBodyLengthState クラスの作成

## 該当する issue

- #90 

## 変更内容
Content-Lengthが指定されている時のbody読み込みのためのクラスを作成

- 変更点
  - ReadBufferクラスにbufサイズを返すsize()関数を付加

## 影響範囲
- http/request/read/length_body.(cpp/hpp)
- io/input/read/buffer.(cpp/hpp)

## その他
途中でデータが入ってこなくなるなどのエラー処理は、ソケット側でタイムアウト処理をしなければならないので、ここでは対処しない