### PR TITLE
32 feat read request chunked

### DIFF
--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -26,7 +26,6 @@ class ReadingRequestBodyChunkedState : public IState {
     };
 
     Phase phase_;
-    std::string buffer_;            // 一時的に読み込んだ未処理データ
     std::size_t currentChunkSize_;  // 現在処理中のチャンクサイズ
     std::size_t alreadyRead_;       // 現在のチャンクで読み込んだバイト数
     std::string body_;              // 完成したボディを貯めるバッファ

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -14,6 +14,8 @@ class ReadingRequestBodyChunkedState : public IState {
     virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
     TransitionResult handleReadSize(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadData(ReadBuffer& buf, TransitionResult& tr);
+    bool tryLoadBufferIfEmpty(ReadBuffer& buf, TransitionResult& tr);
+    bool handleReadCRLFIfDone(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr,
                                        ReadContext& ctx);
     TransitionResult handleDone(ReadContext& ctx, TransitionResult& tr);

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "buffer.hpp"
-#include "state.hpp"
 #include "context.hpp"
+#include "state.hpp"
 
 namespace http {
 
@@ -14,7 +14,8 @@ class ReadingRequestBodyChunkedState : public IState {
     virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
     TransitionResult handleReadSize(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadData(ReadBuffer& buf, TransitionResult& tr);
-    TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr);
+    TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr,
+                                       ReadContext& ctx);
     TransitionResult handleDone(ReadContext& ctx, TransitionResult& tr);
 
    private:

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -2,6 +2,7 @@
 
 #include "buffer.hpp"
 #include "state.hpp"
+#include "context.hpp"
 
 namespace http {
 
@@ -14,10 +15,15 @@ class ReadingRequestBodyChunkedState : public IState {
     TransitionResult handleReadSize(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadData(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr);
-    TransitionResult handleDone(TransitionResult& tr);
+    TransitionResult handleDone(ReadContext& ctx, TransitionResult& tr);
 
    private:
-    enum Phase { kChunkReadSize, kChunkReadData, kChunkReadTrailer, kChunkDone };
+    enum Phase {
+        kChunkReadSize,
+        kChunkReadData,
+        kChunkReadTrailer,
+        kChunkDone
+    };
 
     Phase phase_;
     std::string buffer_;            // 一時的に読み込んだ未処理データ

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -14,7 +14,7 @@ class ReadingRequestBodyChunkedState : public IState {
     virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
     TransitionResult handleReadSize(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadData(ReadBuffer& buf, TransitionResult& tr);
-    bool tryLoadBufferIfEmpty(ReadBuffer& buf, TransitionResult& tr);
+    bool tryLoadBufferIfEmpty(ReadBuffer& buf, TransitionResult& tr) const;
     bool handleReadCRLFIfDone(ReadBuffer& buf, TransitionResult& tr);
     TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr,
                                        ReadContext& ctx);

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "buffer.hpp"
+#include "state.hpp"
+
+namespace http {
+
+class ReadingRequestBodyChunkedState : public IState {
+   public:
+    explicit ReadingRequestBodyChunkedState();
+    virtual ~ReadingRequestBodyChunkedState();
+
+    virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
+    std::size_t parseHex(const std::string& hex);  // 16進数を変換する
+
+   private:
+    enum Phase { kReadSize, kReadData, kReadTrailer, kDone };
+
+    Phase phase_;
+    std::string buffer_;            // 一時的に読み込んだ未処理データ
+    std::size_t currentChunkSize_;  // 現在処理中のチャンクサイズ
+    std::size_t alreadyRead_;       // 現在のチャンクで読み込んだバイト数
+    std::string body_;              // 完成したボディを貯めるバッファ
+};
+}  // namespace http

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -11,10 +11,13 @@ class ReadingRequestBodyChunkedState : public IState {
     virtual ~ReadingRequestBodyChunkedState();
 
     virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
-    std::size_t parseHex(const std::string& hex);  // 16進数を変換する
+    TransitionResult handleReadSize(ReadBuffer& buf, TransitionResult& tr);
+    TransitionResult handleReadData(ReadBuffer& buf, TransitionResult& tr);
+    TransitionResult handleReadTrailer(ReadBuffer& buf, TransitionResult& tr);
+    TransitionResult handleDone(TransitionResult& tr);
 
    private:
-    enum Phase { kReadSize, kReadData, kReadTrailer, kDone };
+    enum Phase { kChunkReadSize, kChunkReadData, kChunkReadTrailer, kChunkDone };
 
     Phase phase_;
     std::string buffer_;            // 一時的に読み込んだ未処理データ

--- a/include/http/request/read/context.hpp
+++ b/include/http/request/read/context.hpp
@@ -20,6 +20,7 @@ class ReadContext {
   config::IConfigResolver& getConfigResolver() const;
   const std::string& getRequestLine() const;
   const RawHeaders& getHeaders() const;
+  void setBody(const std::string& body);
   const std::string& getBody() const;
   types::Option<IState*> createReadingBodyState(const RawHeaders& headers);
 

--- a/include/http/request/read/length_body.hpp
+++ b/include/http/request/read/length_body.hpp
@@ -22,9 +22,9 @@ class ReadingRequestBodyLengthState : public IState {
     std::size_t alreadyRead_;
     std::string bodyBuffer_;
 
-    static TransitionResult done_(const std::string& body);
-    static TransitionResult error_(TransitionResult& tr, error::AppError err);
-    static bool ensureData_(ReadBuffer& buf, TransitionResult& tr);
-    static TransitionResult suspend_(TransitionResult& tr);
+    static TransitionResult done(const std::string& body);
+    static TransitionResult error(TransitionResult& tr, error::AppError err);
+    static bool ensureData(ReadBuffer& buf, TransitionResult& tr);
+    static TransitionResult suspend(TransitionResult& tr);
 };
 }  // namespace http

--- a/include/http/request/read/length_body.hpp
+++ b/include/http/request/read/length_body.hpp
@@ -15,11 +15,16 @@ class ReadingRequestBodyLengthState : public IState {
     explicit ReadingRequestBodyLengthState(const BodyLengthConfig& config);
     virtual ~ReadingRequestBodyLengthState();
     virtual TransitionResult handle(ReadContext& ctx, ReadBuffer& buf);
-
+    
    private:
     std::size_t contentLength_;
     std::size_t clientMaxBodySize_;
     std::size_t alreadyRead_;
     std::string bodyBuffer_;
+
+    static TransitionResult done_(const std::string& body);
+    static TransitionResult error_(TransitionResult& tr, error::AppError err);
+    static bool ensureData_(ReadBuffer& buf, TransitionResult& tr);
+    static TransitionResult suspend_(TransitionResult& tr);
 };
 }  // namespace http

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -8,5 +8,5 @@ namespace utils {
 bool startsWith(const std::string& str, const std::string& prefix);
 std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
-std::size_t parseHex(const std::string& hex);  // 16進数を変換する
+types::Result<std::size_t, error::AppError> parseHex(const std::string& hex);  // 16進数を変換する
 }  // namespace utils

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -8,4 +8,5 @@ namespace utils {
 bool startsWith(const std::string& str, const std::string& prefix);
 std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
+std::size_t parseHex(const std::string& hex);  // 16進数を変換する
 }  // namespace utils

--- a/src/http/request/read/body.cpp
+++ b/src/http/request/read/body.cpp
@@ -16,9 +16,9 @@ ReadingRequestBodyState::ReadingRequestBodyState(BodyEncodingType type,
         case kContentLength:
             activeBodyState_ = new ReadingRequestBodyLengthState(config);
             break;
-        // case kChunked:
-        //     activeBodyState_ = new ReadingRequestBodyChunkedState();
-        //     break;
+        case kChunked:
+            activeBodyState_ = new ReadingRequestBodyChunkedState();
+            break;
         default:
             activeBodyState_ = NULL;  // Handle unsupported types
             break;

--- a/src/http/request/read/chunked_body.cpp
+++ b/src/http/request/read/chunked_body.cpp
@@ -1,15 +1,18 @@
 #include "chunked_body.hpp"
 
+#include "buffer.hpp"
 #include "state.hpp"
 #include "context.hpp"
+#include "utils.hpp"
 #include "utils/types/error.hpp"
 #include "utils/types/option.hpp"
 #include "utils/types/result.hpp"
+#include "utils/string.hpp"
 
 namespace http {
 
 ReadingRequestBodyChunkedState::ReadingRequestBodyChunkedState()
-    : phase_(kReadSize), currentChunkSize_(0), alreadyRead_(0) {}
+    : phase_(kChunkReadSize), currentChunkSize_(0), alreadyRead_(0) {}
 
 ReadingRequestBodyChunkedState::~ReadingRequestBodyChunkedState() {}
 
@@ -19,17 +22,105 @@ TransitionResult ReadingRequestBodyChunkedState::handle(ReadContext& ctx,
     TransitionResult tr;
 
     while (true) {
-        if (phase_ == kReadSize) {
-            const GetLineResult result = getLine(buf);
-            if (result.isErr()) {
-                return tr.setStatus(types::err(result.unwrapErr())), tr;
-            }
-            const types::Option<std::string> lineOpt = result.unwrap();
-            if (lineOpt.isNone()) {
-                return tr.setStatus(types::ok(kSuspend)), tr;
-            }
-            
+        switch (phase_) {
+            case kChunkReadSize:
+                return handleReadSize(buf, tr);
+            case kChunkReadData:
+                return handleReadData(buf, tr);
+            case kChunkReadTrailer:
+                return handleReadTrailer(buf, tr);
+            case kChunkDone:
+                return handleDone(tr);
         }
     }
 }
+
+TransitionResult ReadingRequestBodyChunkedState::handleReadSize(ReadBuffer& buf, TransitionResult& tr) {
+    const GetLineResult result = getLine(buf);
+
+    if (result.isErr()) {
+        tr.setStatus(types::err(result.unwrapErr()));
+        return tr;
+    }
+
+    const types::Option<std::string> lineOpt = result.unwrap();    
+
+    if (lineOpt.isNone()) {
+        tr.setStatus(types::ok(kSuspend));
+        return tr;
+    }
+
+    const std::string line = lineOpt.unwrap();
+    currentChunkSize_ = utils::parseHex(line);
+    alreadyRead_ = 0;
+
+    if (currentChunkSize_ == 0) {
+        phase_ = kChunkReadTrailer;
+    } else {
+        phase_ = kChunkReadData;
+    }
+
+    tr.setStatus(types::ok(kSuspend));
+    return tr;
+}
+
+TransitionResult ReadingRequestBodyChunkedState::handleReadData(ReadBuffer& buf, TransitionResult& tr) {
+    const std::size_t remain = currentChunkSize_ - alreadyRead_;
+    const std::size_t toRead = std::min(remain, buf.size());
+
+    if (toRead == 0) {
+        const ReadBuffer::LoadResult loadResult = buf.load();
+        if (loadResult.isErr()) {
+            return tr.setStatus(types::err(loadResult.unwrapErr())), tr;
+        }
+        return tr.setStatus(types::ok(kSuspend)), tr;
+    }
+
+    const std::string chunk = buf.consume(toRead);
+    body_ += chunk;
+    alreadyRead_ += chunk.size();
+    if (alreadyRead_ >= currentChunkSize_) {
+        phase_ = kChunkReadSize;
+        const GetLineResult crlf = getLine(buf);
+        if (crlf.isErr()) {
+            return tr.setStatus(types::err(crlf.unwrapErr())), tr;
+        }
+        if (crlf.unwrap().isNone()) {
+            return tr.setStatus(types::ok(kSuspend)), tr;
+        }
+    }
+    return tr.setStatus(types::ok(kSuspend)), tr;
+}
+
+TransitionResult ReadingRequestBodyChunkedState::handleReadTrailer(ReadBuffer& buf, TransitionResult& tr) {
+    const GetLineResult result = getLine(buf);
+
+    if (result.isErr()) {
+        tr.setStatus(types::err(result.unwrapErr()));
+        return tr;
+    }
+
+    const types::Option<std::string> lineOpt = result.unwrap();
+
+    if (lineOpt.isNone()) {
+        tr.setStatus(types::ok(kSuspend));
+        return tr;
+    }
+
+    const std::string line = lineOpt.unwrap();
+
+    if (line.empty()) {
+        phase_ = kChunkDone;
+    }
+
+    tr.setStatus(types::ok(kSuspend));
+    return tr;
+}
+
+TransitionResult ReadingRequestBodyChunkedState::handleDone(TransitionResult& tr) {
+    tr.setBody(types::some(body_));
+    tr.setStatus(types::ok(kDone));
+    return tr;
+}
+
 }  // namespace http

--- a/src/http/request/read/chunked_body.cpp
+++ b/src/http/request/read/chunked_body.cpp
@@ -18,7 +18,6 @@ ReadingRequestBodyChunkedState::~ReadingRequestBodyChunkedState() {}
 
 TransitionResult ReadingRequestBodyChunkedState::handle(ReadContext& ctx,
                                                         ReadBuffer& buf) {
-    // (void)ctx;
     TransitionResult tr;
 
     while (true) {

--- a/src/http/request/read/chunked_body.cpp
+++ b/src/http/request/read/chunked_body.cpp
@@ -84,7 +84,7 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadData(
     if (alreadyRead_ == currentChunkSize_) {
         if (!handleReadCRLFIfDone(buf, tr)) {
             return tr;
-        }
+        }    
     }
     return tr.setStatus(types::ok(kSuspend)), tr;
 }

--- a/src/http/request/read/chunked_body.cpp
+++ b/src/http/request/read/chunked_body.cpp
@@ -1,0 +1,35 @@
+#include "chunked_body.hpp"
+
+#include "state.hpp"
+#include "context.hpp"
+#include "utils/types/error.hpp"
+#include "utils/types/option.hpp"
+#include "utils/types/result.hpp"
+
+namespace http {
+
+ReadingRequestBodyChunkedState::ReadingRequestBodyChunkedState()
+    : phase_(kReadSize), currentChunkSize_(0), alreadyRead_(0) {}
+
+ReadingRequestBodyChunkedState::~ReadingRequestBodyChunkedState() {}
+
+TransitionResult ReadingRequestBodyChunkedState::handle(ReadContext& ctx,
+                                                       ReadBuffer& buf) {
+    (void)ctx;
+    TransitionResult tr;
+
+    while (true) {
+        if (phase_ == kReadSize) {
+            const GetLineResult result = getLine(buf);
+            if (result.isErr()) {
+                return tr.setStatus(types::err(result.unwrapErr())), tr;
+            }
+            const types::Option<std::string> lineOpt = result.unwrap();
+            if (lineOpt.isNone()) {
+                return tr.setStatus(types::ok(kSuspend)), tr;
+            }
+            
+        }
+    }
+}
+}  // namespace http

--- a/src/http/request/read/chunked_body.cpp
+++ b/src/http/request/read/chunked_body.cpp
@@ -1,13 +1,13 @@
 #include "chunked_body.hpp"
 
 #include "buffer.hpp"
-#include "state.hpp"
 #include "context.hpp"
+#include "state.hpp"
 #include "utils.hpp"
+#include "utils/string.hpp"
 #include "utils/types/error.hpp"
 #include "utils/types/option.hpp"
 #include "utils/types/result.hpp"
-#include "utils/string.hpp"
 
 namespace http {
 
@@ -17,8 +17,8 @@ ReadingRequestBodyChunkedState::ReadingRequestBodyChunkedState()
 ReadingRequestBodyChunkedState::~ReadingRequestBodyChunkedState() {}
 
 TransitionResult ReadingRequestBodyChunkedState::handle(ReadContext& ctx,
-                                                       ReadBuffer& buf) {
-    (void)ctx;
+                                                        ReadBuffer& buf) {
+    // (void)ctx;
     TransitionResult tr;
 
     while (true) {
@@ -30,12 +30,15 @@ TransitionResult ReadingRequestBodyChunkedState::handle(ReadContext& ctx,
             case kChunkReadTrailer:
                 return handleReadTrailer(buf, tr);
             case kChunkDone:
-                return handleDone(tr);
+                return handleDone(ctx, tr);
         }
     }
+    tr.setStatus(types::err(error::kIOUnknown));
+    return tr;
 }
 
-TransitionResult ReadingRequestBodyChunkedState::handleReadSize(ReadBuffer& buf, TransitionResult& tr) {
+TransitionResult ReadingRequestBodyChunkedState::handleReadSize(
+    ReadBuffer& buf, TransitionResult& tr) {
     const GetLineResult result = getLine(buf);
 
     if (result.isErr()) {
@@ -43,7 +46,7 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadSize(ReadBuffer& buf,
         return tr;
     }
 
-    const types::Option<std::string> lineOpt = result.unwrap();    
+    const types::Option<std::string> lineOpt = result.unwrap();
 
     if (lineOpt.isNone()) {
         tr.setStatus(types::ok(kSuspend));
@@ -51,7 +54,11 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadSize(ReadBuffer& buf,
     }
 
     const std::string line = lineOpt.unwrap();
-    currentChunkSize_ = utils::parseHex(line);
+    const types::Result<std::size_t, error::AppError> sizeResult = utils::parseHex(line);
+    if (sizeResult.isErr()) {
+        return tr.setStatus(types::err(sizeResult.unwrapErr())), tr;
+    }
+    currentChunkSize_ = sizeResult.unwrap();
     alreadyRead_ = 0;
 
     if (currentChunkSize_ == 0) {
@@ -64,7 +71,8 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadSize(ReadBuffer& buf,
     return tr;
 }
 
-TransitionResult ReadingRequestBodyChunkedState::handleReadData(ReadBuffer& buf, TransitionResult& tr) {
+TransitionResult ReadingRequestBodyChunkedState::handleReadData(
+    ReadBuffer& buf, TransitionResult& tr) {
     const std::size_t remain = currentChunkSize_ - alreadyRead_;
     const std::size_t toRead = std::min(remain, buf.size());
 
@@ -80,19 +88,25 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadData(ReadBuffer& buf,
     body_ += chunk;
     alreadyRead_ += chunk.size();
     if (alreadyRead_ >= currentChunkSize_) {
-        phase_ = kChunkReadSize;
         const GetLineResult crlf = getLine(buf);
         if (crlf.isErr()) {
             return tr.setStatus(types::err(crlf.unwrapErr())), tr;
         }
-        if (crlf.unwrap().isNone()) {
+        const types::Option<std::string> lineOpt = crlf.unwrap();
+        if (lineOpt.isNone()) {
             return tr.setStatus(types::ok(kSuspend)), tr;
         }
+        const std::string& line = lineOpt.unwrap();
+        if (!line.empty()) {
+            return tr.setStatus(types::err(error::kBadRequest)), tr;
+        }
+        phase_ = kChunkReadSize;
     }
     return tr.setStatus(types::ok(kSuspend)), tr;
 }
 
-TransitionResult ReadingRequestBodyChunkedState::handleReadTrailer(ReadBuffer& buf, TransitionResult& tr) {
+TransitionResult ReadingRequestBodyChunkedState::handleReadTrailer(
+    ReadBuffer& buf, TransitionResult& tr) {
     const GetLineResult result = getLine(buf);
 
     if (result.isErr()) {
@@ -117,7 +131,9 @@ TransitionResult ReadingRequestBodyChunkedState::handleReadTrailer(ReadBuffer& b
     return tr;
 }
 
-TransitionResult ReadingRequestBodyChunkedState::handleDone(TransitionResult& tr) {
+TransitionResult ReadingRequestBodyChunkedState::handleDone(
+    ReadContext& ctx, TransitionResult& tr) {
+    ctx.setBody(body_);
     tr.setBody(types::some(body_));
     tr.setStatus(types::ok(kDone));
     return tr;

--- a/src/http/request/read/context.cpp
+++ b/src/http/request/read/context.cpp
@@ -89,6 +89,10 @@ const std::string& ReadContext::getRequestLine() const { return requestLine_; }
 
 const RawHeaders& ReadContext::getHeaders() const { return headers_; }
 
+void ReadContext::setBody(const std::string& body) {
+    body_ = body;
+}
+
 const std::string& ReadContext::getBody() const { return body_; }
 
 }  // namespace http

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -74,8 +74,8 @@ bool ReadingRequestBodyLengthState::ensureData_(ReadBuffer& buf, TransitionResul
         tr.setStatus(types::err(loadResult.unwrapErr()));
         return false;
     }
-    if (loadResult.canUnwrap() == 0) {
-        tr.setStatus((types::ok(IState::kSuspend)));
+    if (loadResult.unwrap() == 0) {
+        tr.setStatus(types::ok(IState::kSuspend));
         return false;
     }
     return true;

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -26,7 +26,7 @@ TransitionResult ReadingRequestBodyLengthState::handle(ReadContext& ctx,
     if (contentLength_ == 0) {
         return done(std::string(""));
     }
-    if (alreadyRead_ == 0 && contentLength_ > clientMaxBodySize_) {
+    if (contentLength_ > clientMaxBodySize_) {
         return error(tr, error::kRequestEntityTooLarge);
     }
     if (!ensureData(buf, tr)) {

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -24,12 +24,12 @@ TransitionResult ReadingRequestBodyLengthState::handle(ReadContext& ctx,
     TransitionResult tr;
 
     if (contentLength_ == 0) {
-        return done_(std::string(""));
+        return done(std::string(""));
     }
     if (alreadyRead_ == 0 && contentLength_ > clientMaxBodySize_) {
-        return error_(tr, error::kRequestEntityTooLarge);
+        return error(tr, error::kRequestEntityTooLarge);
     }
-    if (!ensureData_(buf, tr)) {
+    if (!ensureData(buf, tr)) {
         return tr;
     }
 
@@ -37,7 +37,7 @@ TransitionResult ReadingRequestBodyLengthState::handle(ReadContext& ctx,
     const std::size_t toRead = std::min(remain, buf.size());
 
     if (toRead == 0) {
-        return suspend_(tr);
+        return suspend(tr);
     }
 
     const std::string segment = buf.consume(toRead);  // 読み取って消費
@@ -52,7 +52,7 @@ TransitionResult ReadingRequestBodyLengthState::handle(ReadContext& ctx,
     return tr;
 }
 
-TransitionResult ReadingRequestBodyLengthState::done_(const std::string& body) {
+TransitionResult ReadingRequestBodyLengthState::done(const std::string& body) {
     TransitionResult tr;
 
     tr.setBody(types::some(body));
@@ -60,12 +60,12 @@ TransitionResult ReadingRequestBodyLengthState::done_(const std::string& body) {
     return tr;
 }
 
-TransitionResult ReadingRequestBodyLengthState::error_(TransitionResult& tr, error::AppError err) {
+TransitionResult ReadingRequestBodyLengthState::error(TransitionResult& tr, error::AppError err) {
     tr.setStatus(types::err(err));
     return tr;
 }
 
-bool ReadingRequestBodyLengthState::ensureData_(ReadBuffer& buf, TransitionResult& tr) {
+bool ReadingRequestBodyLengthState::ensureData(ReadBuffer& buf, TransitionResult& tr) {
     if (buf.size() > 0) {
         return true;
     }
@@ -81,7 +81,7 @@ bool ReadingRequestBodyLengthState::ensureData_(ReadBuffer& buf, TransitionResul
     return true;
 }
 
-TransitionResult ReadingRequestBodyLengthState::suspend_(TransitionResult& tr) {
+TransitionResult ReadingRequestBodyLengthState::suspend(TransitionResult& tr) {
     tr.setStatus(types::ok(IState::kSuspend));
     return tr;
 }

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -3,6 +3,7 @@
 #include <cctype>
 
 static const size_t HEX = 16;
+static const size_t TEN = 10;
 
 bool utils::startsWith(const std::string &str, const std::string &prefix) {
     return str.find(prefix) == 0;
@@ -43,9 +44,9 @@ types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &h
         if (chr >= '0' && chr <= '9') {
             result += static_cast<std::size_t>(hex[i] - '0');
         } else if (chr >= 'a' && chr <= 'f') {
-            result += static_cast<std::size_t>(hex[i] - 'a');
+            result += static_cast<std::size_t>(hex[i] - 'a') + TEN;
         } else if (chr >= 'A' && chr <= 'F') {
-            result += static_cast<std::size_t>(hex[i] - 'A');
+            result += static_cast<std::size_t>(hex[i] - 'A') + TEN;
         } else {
             return types::err(error::kBadRequest);
         }

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -42,11 +42,11 @@ types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &h
         result *= HEX;
 
         if (chr >= '0' && chr <= '9') {
-            result += static_cast<std::size_t>(hex[i] - '0');
+            result += static_cast<std::size_t>(chr - '0');
         } else if (chr >= 'a' && chr <= 'f') {
-            result += static_cast<std::size_t>(hex[i] - 'a') + TEN;
+            result += static_cast<std::size_t>(chr - 'a') + TEN;
         } else if (chr >= 'A' && chr <= 'F') {
-            result += static_cast<std::size_t>(hex[i] - 'A') + TEN;
+            result += static_cast<std::size_t>(chr - 'A') + TEN;
         } else {
             return types::err(error::kBadRequest);
         }

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -2,6 +2,8 @@
 
 #include <cctype>
 
+static const size_t HEX = 16;
+
 bool utils::startsWith(const std::string &str, const std::string &prefix) {
     return str.find(prefix) == 0;
 }
@@ -29,3 +31,25 @@ std::string utils::trim(const std::string &str) {
 
     return str.substr(start, end - start);
 }
+
+std::size_t utils::parseHex(const std::string& hex) {
+    std::size_t result = 0;
+
+    for (std::size_t i = 0; i < hex.size(); ++i) {
+        char chr = hex[i];
+        result *= HEX;
+
+        if (chr >= '0' && chr <= '9') {
+            result += static_cast<std::size_t>(hex[i] - '0');
+        } else if (chr >= 'a' && chr <= 'f') {
+            result += static_cast<std::size_t>(hex[i] - 'a');
+        } else if (chr >= 'A' && chr <= 'F') {
+            result += static_cast<std::size_t>(hex[i] - 'A');
+        } else {
+            break ;
+        }
+
+    }
+    return result;
+}
+

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -11,7 +11,8 @@ bool utils::startsWith(const std::string &str, const std::string &prefix) {
 std::string utils::toLower(const std::string &str) {
     std::string result = str;
     for (std::size_t i = 0; i < result.size(); ++i) {
-        result[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(result[i])));
+        result[i] = static_cast<char>(
+            std::tolower(static_cast<unsigned char>(result[i])));
     }
     return result;
 }
@@ -32,11 +33,11 @@ std::string utils::trim(const std::string &str) {
     return str.substr(start, end - start);
 }
 
-std::size_t utils::parseHex(const std::string& hex) {
+types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &hex) {
     std::size_t result = 0;
 
     for (std::size_t i = 0; i < hex.size(); ++i) {
-        char chr = hex[i];
+        const char chr = hex[i];
         result *= HEX;
 
         if (chr >= '0' && chr <= '9') {
@@ -46,10 +47,8 @@ std::size_t utils::parseHex(const std::string& hex) {
         } else if (chr >= 'A' && chr <= 'F') {
             result += static_cast<std::size_t>(hex[i] - 'A');
         } else {
-            break ;
+            return types::err(error::kBadRequest);
         }
-
     }
-    return result;
+    return types::ok(result);
 }
-

--- a/test/http/request/read/CMakeLists.txt
+++ b/test/http/request/read/CMakeLists.txt
@@ -1,3 +1,4 @@
+enable_testing()
 cmake_minimum_required(VERSION 3.14)
 project(getline_test CXX)
 
@@ -43,6 +44,10 @@ target_link_libraries(body_test
 
 add_executable(body_length_test body_length_test.cpp)
 target_link_libraries(body_length_test
+    PRIVATE webserv_lib gtest gtest_main)
+
+add_executable(body_chunked_test body_chunked_test.cpp)
+target_link_libraries(body_chunked_test
     PRIVATE webserv_lib gtest)
 
 include(GoogleTest)
@@ -53,3 +58,4 @@ gtest_discover_tests(context_test)
 gtest_discover_tests(header_test)
 gtest_discover_tests(body_test) 
 gtest_discover_tests(body_length_test)
+gtest_discover_tests(body_chunked_test)

--- a/test/http/request/read/CMakeLists.txt
+++ b/test/http/request/read/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(body_length_test
 
 add_executable(body_chunked_test body_chunked_test.cpp)
 target_link_libraries(body_chunked_test
-    PRIVATE webserv_lib gtest)
+    PRIVATE webserv_lib gtest gtest_main)
 
 include(GoogleTest)
 gtest_discover_tests(getline_test)

--- a/test/http/request/read/body_chunked_test.cpp
+++ b/test/http/request/read/body_chunked_test.cpp
@@ -57,14 +57,6 @@ TEST(ReadingRequestBodyChunkedStateTest, ReadsChunkedBodyFully) {
                                    << static_cast<int>(result.unwrapErr()) << std::endl;
     } while (result.unwrap() == http::IState::kSuspend);
 
-        // 再読み込み（simulate ソケットがデータ到着する様子）
-        // const ReadBuffer::LoadResult reload = buf.load();
-        // ASSERT_TRUE(reload.isOk()) << "buf.load() failed on retry";
-        // if (reload.unwrap() == 0) {
-            // break;  // EOF
-        // }
-    // }
-
     EXPECT_EQ(result.unwrap(), http::IState::kDone);
     EXPECT_EQ(ctx.getBody(), "Hello");
 }

--- a/test/http/request/read/body_chunked_test.cpp
+++ b/test/http/request/read/body_chunked_test.cpp
@@ -1,0 +1,190 @@
+#include <gtest/gtest.h>
+
+#include "config/context/serverContext.hpp"
+#include "http/config/config_resolver.hpp"
+#include "http/request/read/chunked_body.hpp"
+#include "http/request/read/context.hpp"
+#include "http/request/read/length_body.hpp"
+#include "io/input/read/buffer.hpp"
+#include "io/input/reader/reader.hpp"
+#include "state.hpp"
+#include "utils/types/error.hpp"
+
+namespace {
+
+class DummyReader : public io::IReader {
+   public:
+    explicit DummyReader(const std::string& input) : input_(input), pos_(0) {}
+    types::Result<std::size_t, error::AppError> read(char* dest,
+                                                     std::size_t n) {
+        if (pos_ >= input_.size()) return types::ok(0ul);
+        std::size_t len = std::min(n, input_.size() - pos_);
+        memcpy(dest, input_.data() + pos_, len);
+        pos_ += len;
+        return types::ok(len);
+    }
+    bool eof() { return pos_ >= input_.size(); }
+
+   private:
+    std::string input_;
+    std::size_t pos_;
+};
+
+class DummyResolver : public http::config::IConfigResolver {
+   public:
+    const ServerContext& choseServer(const std::string&) const {
+        static ServerContext dummy("server");
+        return dummy;
+    }
+};
+
+}  // namespace
+
+TEST(ReadingRequestBodyChunkedStateTest, ReadsChunkedBodyFully) {
+    DummyReader reader("5\r\nHello\r\n0\r\n\r\n");
+    ReadBuffer buf(reader);
+    const ReadBuffer::LoadResult loadResult = buf.load();
+    ASSERT_TRUE(loadResult.isOk()) << "buf.load() failed";
+
+    http::ReadingRequestBodyChunkedState* state = new http::ReadingRequestBodyChunkedState();
+    DummyResolver resolver;
+    http::ReadContext ctx(resolver, state);
+
+    http::HandleResult result = types::ok(http::IState::kSuspend);
+    do {
+        result = ctx.handle(buf);
+        ASSERT_TRUE(result.isOk()) << "handle() failed: "
+                                   << static_cast<int>(result.unwrapErr()) << std::endl;
+    } while (result.unwrap() == http::IState::kSuspend);
+
+        // 再読み込み（simulate ソケットがデータ到着する様子）
+        // const ReadBuffer::LoadResult reload = buf.load();
+        // ASSERT_TRUE(reload.isOk()) << "buf.load() failed on retry";
+        // if (reload.unwrap() == 0) {
+            // break;  // EOF
+        // }
+    // }
+
+    EXPECT_EQ(result.unwrap(), http::IState::kDone);
+    EXPECT_EQ(ctx.getBody(), "Hello");
+}
+
+
+class DummyContext : public http::ReadContext {
+   public:
+    DummyContext(http::config::IConfigResolver& r, http::IState* s)
+        : http::ReadContext(r, s) {}
+};
+
+// 追加先: test/http/request/read/body_chunked_test.cpp
+
+TEST(ReadingRequestBodyChunkedStateTest, ParsesChunkedBodyCorrectly) {
+    DummyReader reader("5\r\nHello\r\n5\r\nWorld\r\n0\r\n\r\n");
+    ReadBuffer buf(reader);
+    buf.load();
+
+    http::BodyLengthConfig config = {0, 1024};
+    http::ReadingRequestBodyChunkedState state;
+
+    DummyResolver resolver;
+    DummyContext ctx(resolver, NULL);
+
+    http::TransitionResult result;
+
+    result = state.handle(ctx, buf);  // kChunkReadSize
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadData
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadSize
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadData
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadSize (0)
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadTrailer
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkDone
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kDone);
+    EXPECT_EQ(result.getBody().unwrap(), "HelloWorld");
+}
+
+TEST(ReadingRequestBodyChunkedStateTest, EndsImmediatelyWithZeroChunk) {
+    DummyReader reader("0\r\n\r\n");
+    ReadBuffer buf(reader);
+    buf.load();
+
+    http::ReadingRequestBodyChunkedState state;
+    DummyResolver resolver;
+    DummyContext ctx(resolver, NULL);
+
+    http::TransitionResult result;
+    result = state.handle(ctx, buf);  // kChunkReadSize → 0
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadTrailer
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkDone
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kDone);
+    EXPECT_EQ(result.getBody().unwrap(), "");
+}
+
+TEST(ReadingRequestBodyChunkedStateTest, FailsOnInvalidChunkSize) {
+    DummyReader reader("G\r\nHello\r\n");  // Gは16進数ではない
+    ReadBuffer buf(reader);
+    buf.load();
+
+    http::ReadingRequestBodyChunkedState state;
+    DummyResolver resolver;
+    DummyContext ctx(resolver, NULL);
+
+    http::TransitionResult result = state.handle(ctx, buf);
+    EXPECT_TRUE(result.getStatus().isErr());
+    EXPECT_EQ(result.getStatus().unwrapErr(), error::kBadRequest);
+}
+
+TEST(ReadingRequestBodyChunkedStateTest, SuspendsWhenChunkBodyIsIncomplete) {
+    DummyReader reader("5\r\nHel");  // 5バイト要求だが 3バイトしかない
+    ReadBuffer buf(reader);
+    buf.load();
+
+    http::ReadingRequestBodyChunkedState state;
+    DummyResolver resolver;
+    DummyContext ctx(resolver, NULL);
+
+    http::TransitionResult result;
+    result = state.handle(ctx, buf);  // kChunkReadSize
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(ctx, buf);  // kChunkReadData → buf 不足なので suspend
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+}
+
+TEST(ReadingRequestBodyChunkedStateTest, SuspendsIfTrailerMissingEmptyLine) {
+    DummyReader reader("0\r\nSome-Header: val\r\n");  // \r\nが最後にない
+    ReadBuffer buf(reader);
+    buf.load();
+
+    http::ReadingRequestBodyChunkedState state;
+    DummyResolver resolver;
+    DummyContext ctx(resolver, NULL);
+
+    http::TransitionResult result;
+    result = state.handle(ctx, buf);  // kChunkReadSize
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+
+    result = state.handle(
+        ctx, buf);  // kChunkReadTrailer → \r\n 足りないので suspend
+    EXPECT_EQ(result.getStatus().unwrap(), http::IState::kSuspend);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 概要 / Overview

- ReadingRequestBodyChunkedStateクラスの作成

## 該当する issue

- #32 

## 変更内容

ReadingRequestBodyChunkedStateクラスは5つのphase_を確認しながらボディのリードを進めます
```phase_ == kChunkReadSize は 最初に来るchunkのサイズを読みphase_をkChunkReadDataに移す```
```phase_ == kChunkReadData は 指示されたサイズだけbufに読み込


- 実装内容
　- チャンクサイズ（hex）を読み取る(handleReadSize)
　- チャンクサイズが `0` のとき終了と判断する
　- 各チャンクデータを読み取る（サイズぴったり）(habdleReadData)
　- チャンク間に CRLF があることを確認する 
　- 未知のチャンク拡張 (`;...`) を **無視** する  (handleReadTrailer)
　- チャンク終端後のトレーラーセクションは **空行で終わるまでスキップする** (handleReadTrailer)

## 影響範囲
- ReadContestクラスにsetBody関数を加えました
- length_body_testの内容を厚くしました

## その他
<img width="791" height="469" alt="Screenshot 2025-07-24 at 7 41 12 PM" src="https://github.com/user-attachments/assets/c55b372b-880a-4262-93c4-39a45bfee621" />
