### PR TITLE
86 feat request parser

### DIFF
--- a/include/config/context/serverContext.hpp
+++ b/include/config/context/serverContext.hpp
@@ -28,6 +28,7 @@ class ServerContext {
     void setserverName(const std::string& serverName);
     void addMap(int number, const std::string& fileName);
     void setClientMaxBodySize(size_t size);
+    void addLocation(const LocationContext& location);
 
     const std::string& getValue() const;
     u_int16_t getListen() const;

--- a/include/http/request/parse/http_request.hpp
+++ b/include/http/request/parse/http_request.hpp
@@ -1,11 +1,23 @@
 #pragma once
+#include <string>
+#include <vector>
+#include "header.hpp"        // RawHeaders を含む
+#include "context/locationContext.hpp"
+#include "raw_headers.hpp"
 
 namespace http {
 namespace parse {
 
 class HttpRequest {
-
+   public:
+    void setMethod(const std::string&) {}
+    void setUri(const std::string&) {}
+    void setVersion(const std::string&) {}
+    void setHeaders(const RawHeaders&) {}
+    void setBody(const std::vector<char>&) {}
+    void setLocation(const LocationContext&) {}
+    void setQueryString(const std::string&) {}
 };
 
-} // namespace parse
-} // namespace http
+}  // namespace parse
+}  // namespace http

--- a/include/http/request/parse/http_request.hpp
+++ b/include/http/request/parse/http_request.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace http {
+namespace parse {
+
+class HttpRequest {
+
+};
+
+} // namespace parse
+} // namespace http

--- a/include/http/request/parse/http_request.hpp
+++ b/include/http/request/parse/http_request.hpp
@@ -10,13 +10,13 @@ namespace parse {
 
 class HttpRequest {
    public:
-    void setMethod(const std::string&) {}
-    void setUri(const std::string&) {}
-    void setVersion(const std::string&) {}
-    void setHeaders(const RawHeaders&) {}
-    void setBody(const std::vector<char>&) {}
-    void setLocation(const LocationContext&) {}
-    void setQueryString(const std::string&) {}
+    // void setMethod(const std::string&) {}
+    // void setUri(const std::string&) {}
+    // void setVersion(const std::string&) {}
+    // void setHeaders(const RawHeaders&) {}
+    // void setBody(const std::vector<char>&) {}
+    // void setLocation(const LocationContext&) {}
+    // void setQueryString(const std::string&) {}
 };
 
 }  // namespace parse

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -19,15 +19,15 @@ class HttpRequest;
 
 class RequestParser {
    public:
-    explicit RequestParser(http::ReadContext* ctx);
+    explicit RequestParser(http::ReadContext& ctx);
     ~RequestParser();
 
-    // types::Result<Request, error::AppError> parseRequest();
     types::Result<types::Unit, error::AppError> parseRequestLine();
     types::Result<types::Unit, error::AppError> parseHeaders();
     types::Result<types::Unit, error::AppError> parseBody();
     types::Result<const LocationContext*, error::AppError> choseLocation(
         const std::string& uri) const;
+    types::Result<HttpRequest, error::AppError> parseAll();
 
    private:
     ReadContext* ctx_;
@@ -45,7 +45,6 @@ class RequestParser {
 
     bool checkMissingHost() const;
     bool validateContentLength() const;
-    static bool containNonDigit(const std::string& val);
     bool validateTransferEncoding() const;
     types::Result<HttpRequest, error::AppError> buildRequest() const;
 };

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "utils/types/result.hpp"
-#include "utils/types/error.hpp"
 #include "raw_headers.hpp"
+#include "utils/types/error.hpp"
+#include "utils/types/result.hpp"
 
 class ReadContext;
 class RequestParser;
@@ -12,38 +12,38 @@ class Request;
 namespace http {
 namespace parse {
 
-    class RequestParser {
-       public:
-        explicit RequestParser(const ReadContext& ctx);
-        ~RequestParser();
-    
-        types::Result<Request, error::AppError> parseRequest();
+class RequestParser {
+   public:
+    explicit RequestParser(const ReadContext& ctx);
+    ~RequestParser();
 
-       private:
-        const ReadContext& ctx_;
-        std::string method_;
-        std::string uri_;
-        std::string version_;
+    types::Result<Request, error::AppError> parseRequest();
 
-        RawHeaders headers_;
+   private:
+    const ReadContext& ctx_;
+    std::string method_;
+    std::string uri_;
+    std::string version_;
 
-        std::vector<char> body_;
+    RawHeaders headers_;
 
-        const LocationContext* location_;
-        const ServerContext* server_;
-        const DocumentRootConfig* documentRoot_;
+    std::vector<char> body_;
 
-        types::Result<types::Unit, error::AppError> parseRequestLine();
-        types::Result<types::Unit, error::AppError> parseHeaders();
-        bool checkMissingHost() const;
-        bool validateContentLength() const;
-        bool containNonDigit(const std::string& val) const;
-        bool validateTransferEncoding() const;
-        types::Result<types::Unit, error::AppError> parseBody();
-        Request buildRequest() const;
-        types::Result<const LocationContext*, error::AppError> choseLocation(std::string& uri);
-    };
+    const LocationContext* location_;
+    const ServerContext* server_;
+    const DocumentRootConfig* documentRoot_;
 
-} // namespace parse
-} // namespace http
+    types::Result<types::Unit, error::AppError> parseRequestLine();
+    types::Result<types::Unit, error::AppError> parseHeaders();
+    bool checkMissingHost() const;
+    bool validateContentLength() const;
+    bool containNonDigit(const std::string& val) const;
+    bool validateTransferEncoding() const;
+    types::Result<types::Unit, error::AppError> parseBody();
+    types::Result<HttpRequest, error::AppError> buildRequest() const;
+    types::Result<const LocationContext*, error::AppError> choseLocation(
+        const std::string& uri) const;
+};
 
+}  // namespace parse
+}  // namespace http

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "raw_headers.hpp"
+#include "context.hpp"
 #include "utils/types/error.hpp"
 #include "utils/types/result.hpp"
+#include "config/context/serverContext.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/context/documentRootConfig.hpp"
 
 class ReadContext;
 class RequestParser;
@@ -12,15 +16,22 @@ class Request;
 namespace http {
 namespace parse {
 
+class HttpRequest;
+
 class RequestParser {
    public:
-    explicit RequestParser(const ReadContext& ctx);
+    explicit RequestParser(http::ReadContext* ctx);
     ~RequestParser();
 
-    types::Result<Request, error::AppError> parseRequest();
+    // types::Result<Request, error::AppError> parseRequest();
+    types::Result<types::Unit, error::AppError> parseRequestLine();
+    types::Result<types::Unit, error::AppError> parseHeaders();
+    types::Result<types::Unit, error::AppError> parseBody();
+    types::Result<const LocationContext*, error::AppError> choseLocation(
+        const std::string& uri) const;
 
    private:
-    const ReadContext& ctx_;
+    ReadContext* ctx_;
     std::string method_;
     std::string uri_;
     std::string version_;
@@ -33,16 +44,11 @@ class RequestParser {
     const ServerContext* server_;
     const DocumentRootConfig* documentRoot_;
 
-    types::Result<types::Unit, error::AppError> parseRequestLine();
-    types::Result<types::Unit, error::AppError> parseHeaders();
     bool checkMissingHost() const;
     bool validateContentLength() const;
     bool containNonDigit(const std::string& val) const;
     bool validateTransferEncoding() const;
-    types::Result<types::Unit, error::AppError> parseBody();
     types::Result<HttpRequest, error::AppError> buildRequest() const;
-    types::Result<const LocationContext*, error::AppError> choseLocation(
-        const std::string& uri) const;
 };
 
 }  // namespace parse

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "utils/types/result.hpp"
+#include "utils/types/error.hpp"
+#include "raw_headers.hpp"
+
+class ReadContext;
+class RequestParser;
+class ReadBuffer;
+class Request;
+
+namespace http {
+namespace parse {
+
+    class RequestParser {
+       public:
+        explicit RequestParser(const ReadContext& ctx);
+        ~RequestParser();
+    
+        types::Result<Request, error::AppError> parseRequest();
+
+       private:
+        const ReadContext& ctx_;
+        std::string method_;
+        std::string uri_;
+        std::string version_;
+
+        RawHeaders headers_;
+
+        std::vector<char> body_;
+
+        const LocationContext* location_;
+        const ServerContext* server_;
+        const DocumentRootConfig* documentRoot_;
+
+        types::Result<types::Unit, error::AppError> parseRequestLine();
+        types::Result<types::Unit, error::AppError> parseHeaders();
+        bool checkMissingHost() const;
+        bool validateContentLength() const;
+        bool containNonDigit(const std::string& val) const;
+        bool validateTransferEncoding() const;
+        types::Result<types::Unit, error::AppError> parseBody();
+        Request buildRequest() const;
+        types::Result<const LocationContext*, error::AppError> choseLocation(std::string& uri);
+    };
+
+} // namespace parse
+} // namespace http
+

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -8,10 +8,9 @@
 #include "config/context/locationContext.hpp"
 #include "config/context/documentRootConfig.hpp"
 
-class ReadContext;
-class RequestParser;
-class ReadBuffer;
-class Request;
+namespace http {
+    class ReadContext;
+}
 
 namespace http {
 namespace parse {
@@ -46,7 +45,7 @@ class RequestParser {
 
     bool checkMissingHost() const;
     bool validateContentLength() const;
-    bool containNonDigit(const std::string& val) const;
+    static bool containNonDigit(const std::string& val);
     bool validateTransferEncoding() const;
     types::Result<HttpRequest, error::AppError> buildRequest() const;
 };

--- a/include/http/request/read/context.hpp
+++ b/include/http/request/read/context.hpp
@@ -18,7 +18,9 @@ class ReadContext {
 
   const IState* getState() const;
   config::IConfigResolver& getConfigResolver() const;
+  void setRequestLine(const std::string& line);
   const std::string& getRequestLine() const;
+  void setHeaders(const RawHeaders& headers);
   const RawHeaders& getHeaders() const;
   void setBody(const std::string& body);
   const std::string& getBody() const;

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -9,4 +9,5 @@ bool startsWith(const std::string& str, const std::string& prefix);
 std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
 types::Result<std::size_t, error::AppError> parseHex(const std::string& hex);  // 16進数を変換する
+bool containsNonDigit(const std::string& val);
 }  // namespace utils

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -6,6 +6,15 @@
 
 namespace utils {
 bool startsWith(const std::string& str, const std::string& prefix);
+
+inline bool endsWith(const std::string &str, const std::string &suffix) {
+    if (str.length() < suffix.length()) {
+        return false;
+    }
+    return str.compare(str.length() - suffix.length(), suffix.length(),
+                       suffix) == 0;
+}
+
 std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
 types::Result<std::size_t, error::AppError> parseHex(const std::string& hex);  // 16進数を変換する

--- a/include/utils/types/error.hpp
+++ b/include/utils/types/error.hpp
@@ -12,5 +12,6 @@ namespace error {
         kInvalidTransferEncoding,
         kHasContentLengthAndTransferEncoding,
         kContainNonDigit,
+        kBadLocationContext,
     };
 } // namespace error

--- a/include/utils/types/error.hpp
+++ b/include/utils/types/error.hpp
@@ -5,5 +5,12 @@ namespace error {
         kIOUnknown,
         kBadRequest,
         kRequestEntityTooLarge,   // ← 追加：413 Payload Too Large
+        kBadMethod,
+        kBadHttpVersion,
+        kMissingHost,
+        kInvalidContentLength,
+        kInvalidTransferEncoding,
+        kHasContentLengthAndTransferEncoding,
+        kContainNonDigit,
     };
 } // namespace error

--- a/include/utils/types/error.hpp
+++ b/include/utils/types/error.hpp
@@ -11,7 +11,7 @@ namespace error {
         kInvalidContentLength,
         kInvalidTransferEncoding,
         kHasContentLengthAndTransferEncoding,
-        kContainNonDigit,
+        kcontainsNonDigit,
         kBadLocationContext,
     };
 } // namespace error

--- a/include/utils/types/error.hpp
+++ b/include/utils/types/error.hpp
@@ -13,5 +13,6 @@ namespace error {
         kHasContentLengthAndTransferEncoding,
         kcontainsNonDigit,
         kBadLocationContext,
+        kUriTooLong,
     };
 } // namespace error

--- a/include/utils/types/result.hpp
+++ b/include/utils/types/result.hpp
@@ -90,6 +90,12 @@ namespace types {
 // #define ERR(e) ::types::err(e)
 #define OK(val) (::types::ok(val))
 #define ERR(e)  (::types::err(e))
+#define RETURN_IF_ERR(expr) \
+    do { \
+        const types::Result<types::Unit, error::AppError> _res = (expr); \
+        if (_res.isErr()) \
+            return ERR(_res.unwrapErr()); \
+    } while (0)
 
 // 「成功」「失敗」を型で安全に扱うための仕組み
 // RustのResult<T, E>型をC++で再現した実装

--- a/include/utils/types/result.hpp
+++ b/include/utils/types/result.hpp
@@ -23,6 +23,9 @@ public:
 };
 
 namespace types {
+
+    struct Unit {}; // Rustに相当
+
     template<typename T, typename E>
     class Result {
         Ok<T>* ok_;

--- a/src/config/context/serverContext.cpp
+++ b/src/config/context/serverContext.cpp
@@ -27,6 +27,10 @@ void ServerContext::setClientMaxBodySize(size_t size) {
     this->clientMaxBodySize_ = size;
 }
 
+void ServerContext::addLocation(const LocationContext& location) {
+    locations_.push_back(location);
+}
+
 const std::string& ServerContext::getValue() const { return (this->value_); }
 
 u_int16_t ServerContext::getListen() const { return (this->listen_); }

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -1,0 +1,112 @@
+#include "request_parser.hpp"
+#include "locationContext.hpp"
+#include "context.hpp"
+#include "utils/string.hpp"
+#include <string>
+#include <sstream>
+
+
+namespace http {
+namespace parse {
+
+RequestParser::RequestParser(const ReadContext& ctx) 
+    : ctx_(ctx) {}
+
+RequestParser::~RequestParser() {}
+
+types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
+    const std::string& line = ctx_.getRequestLine();
+    std::istringstream iss(line);
+    std::string method, uri, version;
+
+    if (!(iss >> method >> uri >> version)) {
+        return ERR(error::kBadRequest);
+    }
+    if (method != "GET" && method != "POST" && method != "DELETE") {
+        return ERR(error::kBadMethod);
+    }
+    if (version.substr(0, 8) != "HTTP/1.1") {
+        return ERR(error::kBadHttpVersion);
+    }
+    method_ = method;
+    uri_ = uri;
+    version_ = version;
+    return OK(types::Unit());
+}
+
+types::Result<types::Unit, error::AppError> RequestParser::parseHeaders() {
+    if (checkMissingHost()) {
+        return ERR(error::kMissingHost);
+    }
+    const bool hasCL = headers_.find("Content-Length") != headers_.end();
+    if (hasCL && !validateContentLength()) {
+        return Err(error::kInvalidContentLength);
+    }
+    const bool hasTE = headers_.find("Transfer-Encoding") != headers_.end();
+    if (hasTE && !validateTransferEncoding()) {
+        return ERR(error::kInvalidTransferEncoding);
+    }
+    if (hasCL && hasTE) {
+        return ERR(error::kHasContentLengthAndTransferEncoding);
+    }
+    return OK(types::Unit());
+}
+
+bool RequestParser::checkMissingHost() const {
+    return headers_.find("Host") == headers_.end();
+}
+
+bool RequestParser::validateContentLength() const {
+    RawHeaders::const_iterator it = headers_.find("Content-Length");
+    if (it == headers_.end()) {
+        return false;
+    }
+    const std::string& val = it->second;
+    return !val.empty() && !containNonDigit(val);
+}
+
+bool RequestParser::containNonDigit(const std::string& val) const {
+    for (std::size_t i = 0; i < val.size(); ++i) {
+        const char chr = val[i];
+
+        if (!std::isdigit(static_cast<unsigned char>(chr))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool RequestParser::validateTransferEncoding() const {
+    RawHeaders::const_iterator it = headers_.find("Transfer-Encoding");
+    if (it == headers_.end()) {
+        return false;
+    }
+    const std::string& val = it->second;
+    return !val.empty() && utils::toLower(val) == "chunked";
+}
+
+types::Result<const LocationContext*, error::AppError> RequestParser::choseLocation(
+    std::string& uri) {
+    const ServerContext& server = ctx_.getServer();
+    const std::vector<LocationContext>& locations = server.getLocation();
+    const LocationContext* bestMatch = NULL;
+    std::size_t longest = 0;
+
+    for (std::size_t i = 0; i < locations.size(); ++i) {
+        const std::string& path = locations[i].getPath();
+        if (uri.compare(0, path.size(), path) == 0) {
+            if (path.size() > longest) {
+                longest = path.size();
+                bestMatch = &locations[i];
+            }
+        }
+    }
+    if (bestMatch) {
+        return types::ok(bestMatch);
+    }
+    return types::err(error::kBadRequest);
+}
+
+} // namespace parse
+}
+

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -93,7 +93,8 @@ bool RequestParser::validateTransferEncoding() const {
 
 types::Result<types::Unit, error::AppError> RequestParser::parseBody() {
     const std::string& raw = ctx_->getBody();
-    // バイナリ対応のため vector<char> に詰め直す    body_.assign(raw.begin(), raw.end());
+    // バイナリ対応のため vector<char> に詰め直す    body_.assign(raw.begin(),
+    // raw.end());
     return OK(types::Unit());
 }
 

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -13,6 +13,8 @@
 namespace http {
 namespace parse {
 
+static const std::size_t kMaxRecommendedRequestLineLength = 8000;
+
 RequestParser::RequestParser(http::ReadContext& ctx) : ctx_(&ctx) {}
 
 RequestParser::~RequestParser() {}
@@ -33,7 +35,8 @@ types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     if (method != "GET" && method != "POST" && method != "DELETE") {
         return ERR(error::kBadMethod);
     }
-    if (uri.length() > 8000) {
+
+    if (uri.length() > kMaxRecommendedRequestLineLength) {
         return ERR(error::kUriTooLong);
     }
     const std::size_t kHttpVersionPreFixLen = 8;

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -19,6 +19,9 @@ RequestParser::~RequestParser() {}
 
 types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     const std::string& line = ctx_->getRequestLine();
+    if (!utils::endsWith(line, "\r\n")) {
+        return ERR(error::kBadRequest);
+    }
     std::istringstream iss(line);
     std::string method;
     std::string uri;
@@ -29,6 +32,9 @@ types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     }
     if (method != "GET" && method != "POST" && method != "DELETE") {
         return ERR(error::kBadMethod);
+    }
+    if (uri.length() > 8000) {
+        return ERR(error::kUriTooLong);
     }
     const std::size_t kHttpVersionPreFixLen = 8;
     if (version.substr(0, kHttpVersionPreFixLen) != "HTTP/1.1") {

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -1,4 +1,5 @@
 #include "request_parser.hpp"
+#include "http_request.hpp"
 #include "locationContext.hpp"
 #include "context.hpp"
 #include "utils/string.hpp"
@@ -83,6 +84,16 @@ bool RequestParser::validateTransferEncoding() const {
     }
     const std::string& val = it->second;
     return !val.empty() && utils::toLower(val) == "chunked";
+}
+
+types::Result<types::Unit, error::AppError> RequestParser::parseBody() {
+    const std::string& raw = ctx_.getBody();
+    body_.assign(raw.begin(), raw.end()); // バイナリ対応のため vector<char> に詰め直す
+    return OK(types::Unit());
+}
+
+HttpRequest RequestParser::buildRequest() const {
+
 }
 
 types::Result<const LocationContext*, error::AppError> RequestParser::choseLocation(

--- a/src/http/request/read/body.cpp
+++ b/src/http/request/read/body.cpp
@@ -21,7 +21,10 @@ ReadingRequestBodyState::ReadingRequestBodyState(BodyEncodingType type,
             activeBodyState_ = new ReadingRequestBodyChunkedState();
             break;
         default:
-            activeBodyState_ = NULL;  // Handle unsupported types
+            BodyLengthConfig config0;
+            config0.contentLength = 0;
+            config0.clientMaxBodySize = config_.clientMaxBodySize;
+            activeBodyState_ = new ReadingRequestBodyLengthState(config0); 
             break;
     }
 }

--- a/src/http/request/read/context.cpp
+++ b/src/http/request/read/context.cpp
@@ -85,7 +85,15 @@ config::IConfigResolver& ReadContext::getConfigResolver() const {
     return resolver_;
 }
 
+void ReadContext::setRequestLine(const std::string& line) {
+    requestLine_ = line;
+}
+
 const std::string& ReadContext::getRequestLine() const { return requestLine_; }
+
+void ReadContext::setHeaders(const RawHeaders& headers) {
+    headers_ = headers;
+}
 
 const RawHeaders& ReadContext::getHeaders() const { return headers_; }
 

--- a/src/http/request/read/header.cpp
+++ b/src/http/request/read/header.cpp
@@ -12,6 +12,7 @@
 #include "utils/types/error.hpp"
 #include "utils/types/option.hpp"
 #include "utils/types/result.hpp"
+#include "utils/string.hpp"
 
 namespace http {
 
@@ -49,8 +50,8 @@ TransitionResult ReadingRequestHeadersState::handle(ReadContext& ctx,
             tr.setStatus(types::err(error::kIOUnknown));
             return tr;
         }
-        const std::string key = line.substr(0, colon);
-        const std::string value = line.substr(colon + 1);
+        const std::string key = utils::trim(line.substr(0, colon));
+        const std::string value = utils::trim(line.substr(colon + 1));
         headers.insert(std::make_pair(key, value));
     }
 }

--- a/src/http/request/read/header.cpp
+++ b/src/http/request/read/header.cpp
@@ -42,12 +42,16 @@ TransitionResult ReadingRequestHeadersState::handle(ReadContext& ctx,
             return tr;
         }
         const std::string line = lineOpt.unwrap();
+        if (!line.empty() && (line[0] == ' ' || line[0] == '\t')) {
+            tr.setStatus(types::err(error::kBadRequest));
+            return tr;
+        }
         if (line.empty()) {
             return handleHeadersComplete(ctx, tr, headers);
         }
         const std::string::size_type colon = line.find(':');
-        if (colon == std::string::npos) {
-            tr.setStatus(types::err(error::kIOUnknown));
+        if (colon == std::string::npos || colon == 0 || std::isspace(line[colon - 1])) {
+            tr.setStatus(types::err(error::kBadRequest));
             return tr;
         }
         const std::string key = utils::trim(line.substr(0, colon));

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -34,7 +34,8 @@ std::string utils::trim(const std::string &str) {
     return str.substr(start, end - start);
 }
 
-types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &hex) {
+types::Result<std::size_t, error::AppError> utils::parseHex(
+    const std::string &hex) {
     std::size_t result = 0;
 
     for (std::size_t i = 0; i < hex.size(); ++i) {
@@ -54,7 +55,7 @@ types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &h
     return types::ok(result);
 }
 
-bool utils::containsNonDigit(const std::string& val) {
+bool utils::containsNonDigit(const std::string &val) {
     for (std::size_t i = 0; i < val.size(); ++i) {
         const char chr = val[i];
 
@@ -64,4 +65,3 @@ bool utils::containsNonDigit(const std::string& val) {
     }
     return false;
 }
-

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -53,3 +53,15 @@ types::Result<std::size_t, error::AppError> utils::parseHex(const std::string &h
     }
     return types::ok(result);
 }
+
+bool utils::containsNonDigit(const std::string& val) {
+    for (std::size_t i = 0; i < val.size(); ++i) {
+        const char chr = val[i];
+
+        if (!std::isdigit(static_cast<unsigned char>(chr))) {
+            return true;
+        }
+    }
+    return false;
+}
+

--- a/test/http/request/CMakeLists.txt
+++ b/test/http/request/CMakeLists.txt
@@ -10,3 +10,4 @@ target_link_libraries(request_test PRIVATE webserv_lib gtest)
 gtest_discover_tests(request_test)
 
 add_subdirectory(read)
+add_subdirectory(parse)

--- a/test/http/request/parse/CMakeLists.txt
+++ b/test/http/request/parse/CMakeLists.txt
@@ -1,0 +1,15 @@
+include_directories(
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/include/utils/types
+    ${CMAKE_SOURCE_DIR}/include/http
+    ${CMAKE_SOURCE_DIR}/include/http/request
+    ${CMAKE_SOURCE_DIR}/include/http/request/parse
+    ${CMAKE_SOURCE_DIR}/include/http/config
+)
+
+add_executable(request_parse_test
+    request_parse_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/http/request/parse/request_parser.cpp
+)
+target_link_libraries(request_parse_test PRIVATE webserv_lib gtest gtest_main)
+gtest_discover_tests(request_parse_test)

--- a/test/http/request/parse/request_parse_test.cpp
+++ b/test/http/request/parse/request_parse_test.cpp
@@ -32,7 +32,7 @@ TEST(RequestParserTest, ParsesValidRequestLine) {
   DummyResolver resolver;
   http::ReadContext ctx(resolver, 0);
 
-  ctx.setRequestLine("GET /index.html HTTP/1.1");
+  ctx.setRequestLine("GET /index.html HTTP/1.1\r\n");
   http::parse::RequestParser parser(ctx);
   types::Result<types::Unit, error::AppError> result = parser.parseRequestLine();
 

--- a/test/http/request/parse/request_parse_test.cpp
+++ b/test/http/request/parse/request_parse_test.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+#include "http/request/parse/request_parser.hpp"
+#include "http/config/config_resolver.hpp"
+#include "http/request/read/context.hpp"
+#include "context/locationContext.hpp"
+#include "config/context/serverContext.hpp"
+#include "http/request/parse/http_request.hpp"
+
+namespace {
+
+class DummyResolver : public http::config::IConfigResolver {
+ public:
+  types::Result<const ServerContext*, error::AppError>
+  choseServer(const std::string&) const override {
+    static ServerContext dummy("server");
+    return types::ok(static_cast<const ServerContext*>(&dummy));
+  }
+};
+
+RawHeaders makeValidHeaders() {
+  RawHeaders headers;
+  headers["Host"] = "localhost";
+  headers["Content-Length"] = "5";
+  return headers;
+}
+
+}  // namespace
+
+
+// parseRequestLine
+TEST(RequestParserTest, ParsesValidRequestLine) {
+  DummyResolver resolver;
+  http::ReadContext ctx(resolver, NULL);  // const を外した
+
+  ctx.setRequestLine("GET /index.html HTTP/1.1");
+  http::parse::RequestParser parser(&ctx);
+  types::Result<types::Unit, error::AppError> result = parser.parseRequestLine();
+
+  EXPECT_TRUE(result.isOk());
+}
+
+// parseHeaders 正常系
+TEST(RequestParserTest, ParsesValidHeaders) {
+  DummyResolver resolver;
+  http::ReadContext ctx(resolver, NULL);
+  ctx.setHeaders(makeValidHeaders());
+
+  http::parse::RequestParser parser(&ctx);
+  types::Result<types::Unit, error::AppError> result = parser.parseHeaders();
+
+  EXPECT_TRUE(result.isOk());
+}
+
+// parseHeaders 異常系（Host 欠如）
+TEST(RequestParserTest, ReturnsErrorWhenHostMissing) {
+  DummyResolver resolver;
+  http::ReadContext ctx(resolver, NULL);
+
+  RawHeaders headers;
+  headers["Content-Length"] = "10";  // Host がない
+  ctx.setHeaders(headers);
+
+  http::parse::RequestParser parser(&ctx);
+  types::Result<types::Unit, error::AppError> result = parser.parseHeaders();
+
+  EXPECT_TRUE(result.isErr());
+  EXPECT_EQ(result.unwrapErr(), error::kMissingHost);
+}
+
+// テスト：parseBody
+TEST(RequestParserTest, ParsesBodyCorrectly) {
+  DummyResolver resolver;
+  http::ReadContext ctx(resolver, NULL);
+  ctx.setBody("ABCDE");
+
+  http::parse::RequestParser parser(&ctx);
+  types::Result<types::Unit, error::AppError> result = parser.parseBody();
+
+  EXPECT_TRUE(result.isOk());
+}
+
+// テスト：choseLocation
+TEST(RequestParserTest, ChoosesCorrectLocation) {
+  DummyResolver resolver;
+  http::ReadContext ctx(resolver, NULL);
+
+  // ServerContext に LocationContext を追加
+  ServerContext server("server");
+
+  LocationContext rootLoc("server");
+  rootLoc.setPath("/");  // ← マッチさせたい prefix にする
+  server.addLocation(rootLoc);  // ← 適切な関数名に置き換えてください
+
+  ctx.setServer(server);
+
+  http::parse::RequestParser parser(&ctx);
+  std::string uri = "/";
+
+  types::Result<const LocationContext*, error::AppError> result = parser.choseLocation(uri);
+
+  ASSERT_TRUE(result.isOk());
+  EXPECT_EQ(result.unwrap()->getPath(), "/");
+}

--- a/test/http/request/parse/request_parse_test.cpp
+++ b/test/http/request/parse/request_parse_test.cpp
@@ -30,10 +30,10 @@ RawHeaders makeValidHeaders() {
 // parseRequestLine
 TEST(RequestParserTest, ParsesValidRequestLine) {
   DummyResolver resolver;
-  http::ReadContext ctx(resolver, NULL);  // const を外した
+  http::ReadContext ctx(resolver, 0);
 
   ctx.setRequestLine("GET /index.html HTTP/1.1");
-  http::parse::RequestParser parser(&ctx);
+  http::parse::RequestParser parser(ctx);
   types::Result<types::Unit, error::AppError> result = parser.parseRequestLine();
 
   EXPECT_TRUE(result.isOk());
@@ -45,7 +45,7 @@ TEST(RequestParserTest, ParsesValidHeaders) {
   http::ReadContext ctx(resolver, NULL);
   ctx.setHeaders(makeValidHeaders());
 
-  http::parse::RequestParser parser(&ctx);
+  http::parse::RequestParser parser(ctx);
   types::Result<types::Unit, error::AppError> result = parser.parseHeaders();
 
   EXPECT_TRUE(result.isOk());
@@ -60,7 +60,7 @@ TEST(RequestParserTest, ReturnsErrorWhenHostMissing) {
   headers["Content-Length"] = "10";  // Host がない
   ctx.setHeaders(headers);
 
-  http::parse::RequestParser parser(&ctx);
+  http::parse::RequestParser parser(ctx);
   types::Result<types::Unit, error::AppError> result = parser.parseHeaders();
 
   EXPECT_TRUE(result.isErr());
@@ -73,7 +73,7 @@ TEST(RequestParserTest, ParsesBodyCorrectly) {
   http::ReadContext ctx(resolver, NULL);
   ctx.setBody("ABCDE");
 
-  http::parse::RequestParser parser(&ctx);
+  http::parse::RequestParser parser(ctx);
   types::Result<types::Unit, error::AppError> result = parser.parseBody();
 
   EXPECT_TRUE(result.isOk());
@@ -93,7 +93,7 @@ TEST(RequestParserTest, ChoosesCorrectLocation) {
 
   ctx.setServer(server);
 
-  http::parse::RequestParser parser(&ctx);
+  http::parse::RequestParser parser(ctx);
   std::string uri = "/";
 
   types::Result<const LocationContext*, error::AppError> result = parser.choseLocation(uri);

--- a/test/http/request/read/header_test.cpp
+++ b/test/http/request/read/header_test.cpp
@@ -72,7 +72,7 @@ TEST(ReadingRequestHeadersStateTest, ReturnsErrorWhenHeaderIsMalformed) {
   http::TransitionResult transitionResult = state->handle(ctx, readBuffer);
 
   ASSERT_TRUE(transitionResult.getStatus().isErr());
-  EXPECT_EQ(transitionResult.getStatus().unwrapErr(), error::kIOUnknown);
+  EXPECT_EQ(transitionResult.getStatus().unwrapErr(), error::kBadRequest);
 }
 
 TEST(ReadingRequestHeadersStateTest, ReturnsDoneWhenHeadersEndWithCRLF) {

--- a/test/http/request/read/header_test.cpp
+++ b/test/http/request/read/header_test.cpp
@@ -89,8 +89,8 @@ TEST(ReadingRequestHeadersStateTest, ReturnsDoneWhenHeadersEndWithCRLF) {
   EXPECT_FALSE(transitionResult.getHeaders().isNone());
 
   const RawHeaders& headers = transitionResult.getHeaders().unwrap();
-  EXPECT_EQ(headers.find("Host")->second, " localhost");
-  EXPECT_EQ(headers.find("User-Agent")->second, " Test");
+  EXPECT_EQ(headers.find("Host")->second, "localhost");
+  EXPECT_EQ(headers.find("User-Agent")->second, "Test");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## 概要 / Overview

- RequestParser class作成

## 該当する issue

- #86 

## 変更内容

ReadContext ctx_をコンストラクタの引数として持つRequestParserクラスを作成した

主な働き

１．parseRequestLine()
　　ctxが持つstring requestLineから
　　　method　
　　　uri
　　　version
　　を抽出して格納する
２．parseHeaders()
　　a. "Host"が含まれているかを検証する
　　b. "Content-Length"か含まれていたら有効な数字であるかを検証する
　　c. "Transfer-Encoding"が含まれていたらsecondがchunked"であるかを検証する
　　上記 b,c が両方含まれていたらエラーを返す
３．parseBody()
　　既存のbody_をvector<char>に詰め直す（バイナリ対応のため）
４．buildRequest()
　　パースした内容をHttpRequestにセットする
　　HttpRequestクラスは仮に作ったため各セット関数はコメントアウトした
５．choseLocation()
　　1のuriを使ってServerContextの中からLocationContextを特定し、セットする

## 影響範囲
- ReadContext クラス
- ReadingRequestHeadersState クラス

## その他
utils/types/result.hpp の Resultにstruct Unit {}を追加した
AppError に  errorを追加した
