### PR TITLE
106 create upload handler

### DIFF
--- a/include/http/handler/file/upload.hpp
+++ b/include/http/handler/file/upload.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
-#include "handler.hpp"
 #include "config/config.hpp"
-#include "result.hpp"
+#include "either.hpp"
+#include "handler.hpp"
 #include "http/response/response.hpp"
+#include "result.hpp"
 
 namespace http {
 
 class UploadFileHandler : public IHandler {
    public:
     explicit UploadFileHandler(const DocumentRootConfig& docRootConfig);
-    Either<IAction*, Response> serve(const Request& req);
+    Either<IAction*, Response> serve(const Request& request);
+
    private:
     DocumentRootConfig docRootConfig_;
-    Response serveInternal(const Request& req) const;
+    Response serveInternal(const Request& request) const;
 };
-} // namespace http
+}  // namespace http

--- a/include/http/handler/file/upload.hpp
+++ b/include/http/handler/file/upload.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "handler.hpp"
+#include "config/config.hpp"
+#include "result.hpp"
+#include "http/response/response.hpp"
+
+namespace http {
+
+class UploadFileHandler : public IHandler {
+   public:
+    explicit UploadFileHandler(const DocumentRootConfig& docRootConfig);
+    Either<IAction*, Response> serve(const Request& req);
+   private:
+    DocumentRootConfig docRootConfig_;
+    Response serveInternal(const Request& req) const;
+};
+} // namespace http

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -20,13 +20,15 @@ std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
 types::Result<std::size_t, error::AppError> parseHex(const std::string& hex);  // 16進数を変換する
 bool containsNonDigit(const std::string& val);
-    template <class T>
-    std::string toString(T value) {
-        std::stringstream ss;
-        ss << value;
 
-        return ss.str();
-    }
+std::string joinPath(const std::string& leftPath, const std::string& rightPath);
+template <class T>
+std::string toString(T value) {
+    std::stringstream ss;
+    ss << value;
+
+    return ss.str();
+}
 
 
 

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -20,7 +20,6 @@ std::string toLower(const std::string& str);
 std::string trim(const std::string& str);
 types::Result<std::size_t, error::AppError> parseHex(const std::string& hex);  // 16進数を変換する
 bool containsNonDigit(const std::string& val);
-
 std::string joinPath(const std::string& leftPath, const std::string& rightPath);
 template <class T>
 std::string toString(T value) {

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -30,8 +30,11 @@ Response UploadFileHandler::serveInternal(const Request& request) const {
     if (lastSlash != std::string::npos) {
         const std::string dirPath = fullPath.substr(0, lastSlash);
         struct stat sta;
-        if (stat(dirPath.c_str(), &sta) != 0 || !(sta.st_mode & S_IFDIR)) {
+        if (stat(dirPath.c_str(), &sta) != 0) {
             return ResponseBuilder().status(kStatusNotFound).build();
+        }
+        if (!S_ISDIR(sta.st_mode)) {
+            return ResponseBuilder().status(kStatusForbidden).build();
         }
     }
     // write the body to a file

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -1,0 +1,52 @@
+#include "upload.hpp"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+
+#include "http/response/builder.hpp"
+#include "utils/string.hpp"
+
+namespace http {
+
+UploadFileHandler::UploadFileHandler(const DocumentRootConfig& docRootConfig)
+    : docRootConfig_(docRootConfig) {}
+
+Either<IAction*, Response> UploadFileHandler::serve(const Request& reqest) {
+    return Right(this->serveInternal(reqest));
+}
+
+Response UploadFileHandler::serveInternal(const Request& request) const {
+    const std::string fullPath = utils::joinPath(docRootConfig_.getRoot(),  request.getPath());
+
+    // check the exsistence of the directory
+    std::string::size_type lastSlash = fullPath.rfind('/');
+    if (lastSlash != std::string::npos) {
+        std::string dirPath = fullPath.substr(0, lastSlash);
+        struct stat sta;
+        if (stat(dirPath.c_str(), &sta) != 0 || !(sta.st_mode & S_IFDIR)) {
+            return ResponseBuilder().status(kStatusNotFound).build();
+        }
+    }
+    // write the body to a file
+    int fd = open(fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        return ResponseBuilder().status(kStatusForbidden).build();
+    }
+    const std::vector<char>& body = request.getBody();
+    ssize_t written = write(fd, &body[0], body.size());
+    close(fd);
+
+    if (written < 0 || static_cast<size_t>(written) != body.size()) {
+        return ResponseBuilder().status(kStatusInternalServerError).build();
+    }
+    return ResponseBuilder().status(kStatusCreated).build();
+}
+
+}  // namespace http

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -18,29 +18,29 @@ namespace http {
 UploadFileHandler::UploadFileHandler(const DocumentRootConfig& docRootConfig)
     : docRootConfig_(docRootConfig) {}
 
-Either<IAction*, Response> UploadFileHandler::serve(const Request& reqest) {
-    return Right(this->serveInternal(reqest));
+Either<IAction*, Response> UploadFileHandler::serve(const Request& request) {
+    return Right(this->serveInternal(request));
 }
 
 Response UploadFileHandler::serveInternal(const Request& request) const {
     const std::string fullPath = utils::joinPath(docRootConfig_.getRoot(),  request.getPath());
 
     // check the exsistence of the directory
-    std::string::size_type lastSlash = fullPath.rfind('/');
+    const std::string::size_type lastSlash = fullPath.rfind('/');
     if (lastSlash != std::string::npos) {
-        std::string dirPath = fullPath.substr(0, lastSlash);
+        const std::string dirPath = fullPath.substr(0, lastSlash);
         struct stat sta;
         if (stat(dirPath.c_str(), &sta) != 0 || !(sta.st_mode & S_IFDIR)) {
             return ResponseBuilder().status(kStatusNotFound).build();
         }
     }
     // write the body to a file
-    int fd = open(fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    const int fd = open(fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (fd < 0) {
         return ResponseBuilder().status(kStatusForbidden).build();
     }
     const std::vector<char>& body = request.getBody();
-    ssize_t written = write(fd, &body[0], body.size());
+    const ssize_t written = write(fd, &body[0], body.size());
     close(fd);
 
     if (written < 0 || static_cast<size_t>(written) != body.size()) {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -55,6 +55,23 @@ types::Result<std::size_t, error::AppError> utils::parseHex(
     return types::ok(result);
 }
 
+std::string utils::joinPath(const std::string& leftPath, const std::string& rightPath) {
+    if (leftPath.empty()) {
+        return rightPath;
+    }
+    if (rightPath.empty()) {
+        return leftPath;
+    }
+
+    if (leftPath[leftPath.size() - 1] == '/' && rightPath[0] == '/') {
+        return leftPath + rightPath.substr(1);
+    } else if (leftPath[leftPath.size() - 1] != '/' && rightPath[0] != '/') {
+        return leftPath + "/" + rightPath; 
+    } else {
+        return leftPath + rightPath;
+    }
+}
+
 bool utils::containsNonDigit(const std::string &val) {
     for (std::size_t i = 0; i < val.size(); ++i) {
         const char chr = val[i];

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -65,11 +65,11 @@ std::string utils::joinPath(const std::string& leftPath, const std::string& righ
 
     if (leftPath[leftPath.size() - 1] == '/' && rightPath[0] == '/') {
         return leftPath + rightPath.substr(1);
-    } else if (leftPath[leftPath.size() - 1] != '/' && rightPath[0] != '/') {
-        return leftPath + "/" + rightPath; 
-    } else {
-        return leftPath + rightPath;
     }
+    if (leftPath[leftPath.size() - 1] != '/' && rightPath[0] != '/') {
+        return leftPath + "/" + rightPath; 
+    }
+    return leftPath + rightPath;
 }
 
 bool utils::containsNonDigit(const std::string &val) {

--- a/test/http/handler/file/CMakeLists.txt
+++ b/test/http/handler/file/CMakeLists.txt
@@ -1,18 +1,22 @@
 add_executable(delete_test delete_test.cpp)
 add_executable(redirect_test redirect_test.cpp)
 add_executable(static_test static_test.cpp)
+add_executable(upload_test upload_test.cpp)
 
 # 依存関係を追加
 add_dependencies(delete_test webserv_lib)
 add_dependencies(redirect_test webserv_lib)
 add_dependencies(static_test webserv_lib)
+add_dependencies(upload_test webserv_lib)
 
 # ライブラリをリンク
 target_link_libraries(delete_test PRIVATE webserv_lib gtest_main gmock_main)
 target_link_libraries(redirect_test PRIVATE webserv_lib gtest_main gmock_main)
 target_link_libraries(static_test PRIVATE webserv_lib gtest_main gmock_main)
+target_link_libraries(upload_test PRIVATE webserv_lib gtest_main gmock_main)
 
 # テストを検出
 gtest_discover_tests(delete_test)
 gtest_discover_tests(redirect_test)
 gtest_discover_tests(static_test)
+gtest_discover_tests(upload_test)

--- a/test/http/handler/file/upload_test.cpp
+++ b/test/http/handler/file/upload_test.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <cstdio>  // std::remove
+
+#include "http/handler/file/upload.hpp"
+#include "http/request/request.hpp"
+#include "config/context/documentRootConfig.hpp"
+
+namespace http {
+
+class UploadFileHandlerTest : public ::testing::Test {
+protected:
+    std::string tempDir;
+    std::string filePath;
+    std::string uploadPath;
+
+    void SetUp() {
+        tempDir = "./tmp_upload_test";
+        uploadPath = "/upload_test_file.txt";
+        filePath = tempDir + uploadPath;
+
+        // 一時ディレクトリを作成（存在しない場合）
+        mkdir(tempDir.c_str(), 0755);
+    }
+
+    void TearDown() {
+        std::remove(filePath.c_str());  // ファイル削除
+        rmdir(tempDir.c_str());         // ディレクトリ削除
+    }
+};
+
+TEST_F(UploadFileHandlerTest, UploadsFileSuccessfully) {
+    // ハンドラの準備
+    DocumentRootConfig config;
+    config.setRoot(tempDir);  // temp upload dir
+
+    UploadFileHandler handler(config);
+
+    // ダミーリクエスト作成
+    RawHeaders headers;
+    std::string testContent = "Hello, Upload!";
+    std::vector<char> body(testContent.begin(), testContent.end());
+
+    const ServerContext* server = NULL;
+    const LocationContext* location = NULL;
+
+    Request request(
+        kMethodPost,           // POST メソッド
+        uploadPath,            // pathOnly 相当
+        headers,
+        body,
+        server,
+        location
+    );
+
+    Either<IAction*, Response> result = handler.serve(request);
+    ASSERT_TRUE(result.isRight());
+    EXPECT_EQ(result.unwrapRight().getStatusCode(), kStatusCreated);
+
+    // 実際にファイルができたか確認
+    std::ifstream ifs(filePath.c_str(), std::ios::binary);
+    ASSERT_TRUE(ifs.is_open());
+
+    std::stringstream ss;
+    ss << ifs.rdbuf();
+    EXPECT_EQ(ss.str(), testContent);
+}
+
+}  // namespace http


### PR DESCRIPTION
## 概要 / Overview

- responseのUploadFileHanderクラス作成

## 該当する issue

- #106 

## 実装内容

```
UploadFileHandler::UploadFileHandler(const DocumentRootConfig& docRootConfig)
    : docRootConfig_(docRootConfig) {}

Either<IAction*, Response> UploadFileHandler::serve(const Request& request) {
    return Right(this->serveInternal(request));
}

Response UploadFileHandler::serveInternal(const Request& request) const {
    const std::string fullPath = utils::joinPath(docRootConfig_.getRoot(),  request.getPath());

    // check the exsistence of the directory
    const std::string::size_type lastSlash = fullPath.rfind('/');
    if (lastSlash != std::string::npos) {
        const std::string dirPath = fullPath.substr(0, lastSlash);
        struct stat sta;
        if (stat(dirPath.c_str(), &sta) != 0) {
            return ResponseBuilder().status(kStatusNotFound).build();
        }
        if (!S_ISDIR(sta.st_mode)) {
            return ResponseBuilder().status(kStatusForbidden).build();
        }
    }
    // write the body to a file
    const int fd = open(fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
    if (fd < 0) {
        return ResponseBuilder().status(kStatusForbidden).build();
    }
    const std::vector<char>& body = request.getBody();
    const ssize_t written = write(fd, &body[0], body.size());
    close(fd);

    if (written < 0 || static_cast<size_t>(written) != body.size()) {
        return ResponseBuilder().status(kStatusInternalServerError).build();
    }
    return ResponseBuilder().status(kStatusCreated).build();
}
```

- methodがPOSTである等の判定は済んでいるものとしてのHandlerクラスの実装。操作としては以下を行う

1. fullPathを求める
2. dierctoryの存在をチェックする
3. oepn, write を使ってbodyの内容をfullPath.c_str()のファイルに書き込む

- fullPathの文字列作成のためjoinPath()をutils/string.xppに作成した
```
std::string utils::joinPath(const std::string& leftPath, const std::string& rightPath) {
    if (leftPath.empty()) {
        return rightPath;
    }
    if (rightPath.empty()) {
        return leftPath;
    }

    if (leftPath[leftPath.size() - 1] == '/' && rightPath[0] == '/') {
        return leftPath + rightPath.substr(1);
    }
    if (leftPath[leftPath.size() - 1] != '/' && rightPath[0] != '/') {
        return leftPath + "/" + rightPath; 
    }
    return leftPath + rightPath;
}
```

## 影響範囲
- http/response/handler/file/upload.xpp
- utils/string.xpp

## その他
