### PR TITLE
(X)109 feat update virtual server -> (O) 112 feat move url check to request parser

### DIFF
--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -25,6 +25,11 @@ class RequestParser {
     types::Result<types::Unit, error::AppError> parseBody();
     types::Result<const LocationContext*, error::AppError> chooseLocation(
         const std::string& uri) const;
+    const std::string& getPathOnly() const;
+    const std::string& getQueryString() const;
+    const std::string& getRequestTarget() const;
+    http::HttpMethod getMethod()const;
+
 
    private:
     ReadContext* ctx_;

--- a/include/http/request/parse/request_parser.hpp
+++ b/include/http/request/parse/request_parser.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "raw_headers.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/context/serverContext.hpp"
 #include "context.hpp"
 #include "http/request/request.hpp"
+#include "raw_headers.hpp"
 #include "utils/types/error.hpp"
 #include "utils/types/result.hpp"
-#include "config/context/serverContext.hpp"
-#include "config/context/locationContext.hpp"
 
 namespace http {
-    class ReadContext;
+class ReadContext;
 }
 
 namespace http {
@@ -29,7 +29,7 @@ class RequestParser {
    private:
     ReadContext* ctx_;
     HttpMethod method_;
-    std::string uri_;
+    std::string requestTarget_;
     std::string pathOnly_;
     std::string queryString_;
     std::string version_;
@@ -41,6 +41,8 @@ class RequestParser {
     bool checkMissingHost() const;
     bool validateContentLength() const;
     bool validateTransferEncoding() const;
+    types::Result<types::Unit, error::AppError> decodeAndNormalizeTarget(
+        const std::string& requestTarget);
     types::Result<Request, error::AppError> buildRequest() const;
 };
 

--- a/include/http/request/request.hpp
+++ b/include/http/request/request.hpp
@@ -19,6 +19,8 @@ namespace http {
     explicit Request(
       HttpMethod method,
       const std::string &requestTarget,
+      const std::string &pathOnly,
+      const std::string &queryString,
       const RawHeaders &headers,
       const std::vector<char> &body,
       const ServerContext *server,

--- a/include/utils/path.hpp
+++ b/include/utils/path.hpp
@@ -14,7 +14,7 @@ inline void compressSegmentCore(const std::string& inString,
 //  - keepAbsolute: 入力が絶対パス（先頭 '/'）なら出力でも保持
 //  - keepTrailingSlash: 入力が末尾 '/' なら可能なら保持
 inline std::string compressSegments(const std::string& inString,
-                                    bool keepAbsolude, bool keepTrailingSlash) {
+                                    bool keepAbsolute, bool keepTrailingSlash) {
     const bool isAbs = !inString.empty() && inString[0] == '/';
     const bool hadTrailing =
         !inString.empty() && inString[inString.size() - 1] == '/';
@@ -24,7 +24,7 @@ inline std::string compressSegments(const std::string& inString,
     compressSegmentCore(inString, segs);
     // 再構築
     std::string out;
-    if (keepAbsolude && isAbs) {
+    if (keepAbsolute && isAbs) {
         out.push_back('/');
     }
     for (std::size_t i = 0; i < segs.size(); ++i) {
@@ -33,14 +33,14 @@ inline std::string compressSegments(const std::string& inString,
             out.push_back('/');
         }
     }
-    bool needKeepTrailing = keepTrailingSlash && hadTrailing;
-    bool hasPathContent = (keepAbsolude && isAbs) || !segs.empty();
+    const bool needKeepTrailing = keepTrailingSlash && hadTrailing;
+    const bool hasPathContent = (keepAbsolute && isAbs) || !segs.empty();
     if (needKeepTrailing && hasPathContent) {
         if (!out.empty() && out[out.size() - 1] != '/') {
             out.push_back('/');
         }
     }
-    if (out.empty() && keepAbsolude && isAbs) {
+    if (out.empty() && keepAbsolute && isAbs) {
         out = "/";
     }
     return out;
@@ -88,7 +88,7 @@ inline void compressSegmentCore(const std::string& inString,
 // 事前条件: "%2e" 等は decode_strict 済みで '.' にデコードされていること
 inline std::string removeDotSegments(const std::string& decodedPath) {
     return compressSegments(decodedPath, /*keepAbsolute=*/true,
-                            /*keepTralingSlasy=*/true);
+                            /*keepTrailingSlash=*/true);
 }
 
 // 使い方2
@@ -107,7 +107,7 @@ inline std::string normalizeSlashes(const std::string& pathLike) {
         tmp.push_back(chr);
     }
     return compressSegments(tmp, /*keepAbsolute=*/true,
-                            /*keepTralingSlasy=*/true);
+                            /*keepTrailingSlash=*/true);
 }
 
 }  // namespace path

--- a/include/utils/path.hpp
+++ b/include/utils/path.hpp
@@ -50,9 +50,9 @@ inline void compressSegmentCore(const std::string& inString,
                                 std::vector<std::string>& segs) {
     segs.clear();
     const std::string::size_type stringSize = inString.size();
-    static const int MARGIN = 8;
-    if (segs.capacity() < static_cast<std::size_t>(MARGIN)) {
-        segs.reserve(MARGIN);
+    static const int TEMPORARY_SEGMENT_CAPACITY = 8;
+    if (segs.capacity() < static_cast<std::size_t>(TEMPORARY_SEGMENT_CAPACITY)) {
+        segs.reserve(TEMPORARY_SEGMENT_CAPACITY);
     }
     std::string::size_type i = 0;
     while (i < stringSize) {

--- a/include/utils/path.hpp
+++ b/include/utils/path.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+namespace utils {
+namespace path {
+
+inline void compressSegmentCore(const std::string& inString,
+                                std::vector<std::string>& segs);
+
+// 共通コア：ドットセグメント削除＆連続 '/' 圧縮
+//  - keepAbsolute: 入力が絶対パス（先頭 '/'）なら出力でも保持
+//  - keepTrailingSlash: 入力が末尾 '/' なら可能なら保持
+inline std::string compressSegments(const std::string& inString,
+                                    bool keepAbsolude, bool keepTrailingSlash) {
+    const bool isAbs = !inString.empty() && inString[0] == '/';
+    const bool hadTrailing =
+        !inString.empty() && inString[inString.size() - 1] == '/';
+
+    std::vector<std::string> segs;
+    // 圧縮
+    compressSegmentCore(inString, segs);
+    // 再構築
+    std::string out;
+    if (keepAbsolude && isAbs) {
+        out.push_back('/');
+    }
+    for (std::size_t i = 0; i < segs.size(); ++i) {
+        out += segs[i];
+        if (i + 1 != segs.size()) {
+            out.push_back('/');
+        }
+    }
+    bool needKeepTrailing = keepTrailingSlash && hadTrailing;
+    bool hasPathContent = (keepAbsolude && isAbs) || !segs.empty();
+    if (needKeepTrailing && hasPathContent) {
+        if (!out.empty() && out[out.size() - 1] != '/') {
+            out.push_back('/');
+        }
+    }
+    if (out.empty() && keepAbsolude && isAbs) {
+        out = "/";
+    }
+    return out;
+}
+
+inline void compressSegmentCore(const std::string& inString,
+                                std::vector<std::string>& segs) {
+    segs.clear();
+    const std::string::size_type stringSize = inString.size();
+    static const int MARGIN = 8;
+    if (segs.capacity() < static_cast<std::size_t>(MARGIN)) {
+        segs.reserve(MARGIN);
+    }
+    std::string::size_type i = 0;
+    while (i < stringSize) {
+        while (i < stringSize && inString[i] == '/') {
+            ++i;
+        }
+        std::string::size_type j = i;
+        while (j < stringSize && inString[j] != '/') {
+            ++j;
+        }
+        if (j > i) {  // セグメントが空でなければ
+            const std::string seg = inString.substr(i, j - i);
+            if (seg == ".") {
+                // ignore
+            } else if (seg == "..") {
+                if (!segs.empty()) {
+                    segs.pop_back();
+                } else {
+                    // ignore
+                }
+            } else {
+                segs.push_back(seg);
+            }
+        }
+        i = j;
+    }
+}
+
+// 使い方1
+// RFC 3986 §5.2.4 準拠の dot-segment 除去
+// URL の相対解決や正規化の一部として使う
+// "." / ".." セグメントを削除
+// 事前条件: "%2e" 等は decode_strict 済みで '.' にデコードされていること
+inline std::string removeDotSegments(const std::string& decodedPath) {
+    return compressSegments(decodedPath, /*keepAbsolute=*/true,
+                            /*keepTralingSlasy=*/true);
+}
+
+// 使い方2
+// ファイルシステム用の「スラッシュ正規化」
+//  - バックスラッシュはスラッシュに変換
+//  - その後に dot-segment 除去＆連続 '/' 圧縮
+inline std::string normalizeSlashes(const std::string& pathLike) {
+    std::string tmp;
+    tmp.reserve(pathLike.size());
+
+    for (std::size_t i = 0; i < pathLike.size(); ++i) {
+        char chr = pathLike[i];
+        if (chr == '\\') {
+            chr = '/';
+        }
+        tmp.push_back(chr);
+    }
+    return compressSegments(tmp, /*keepAbsolute=*/true,
+                            /*keepTralingSlasy=*/true);
+}
+
+}  // namespace path
+}  // namespace utils

--- a/include/utils/url.hpp
+++ b/include/utils/url.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <iostream>
+
+namespace utils {
+namespace url {
+
+    // 厳密な %XX デコード（不正なエンコードや危険な制御文字を拒否）
+    // 成功: true（out に上書き） / 失敗: false（out は未定義）
+    // ‘%’が来たら
+    // 1) エスケープシーケンスの妥当性チェック
+    // 2) 16進文字を数値に変換
+    // 3) バイトに復元
+    // 4) ASCII 制御文字かどうか検証
+    // 5) 出力に追加
+    // 6) '%' 以外はそのまま出力
+inline bool decodeStrict(const std::string& src, std::string& out) {
+    static const unsigned char kAsciiSpace = 0x20;
+    out.clear();
+    for (std::size_t i = 0; i < src.size(); ++i) {
+        const unsigned char chr = static_cast<unsigned char>(src[i]);
+        if (chr == '%') {
+            if (i + 2 >= src.size()) {
+                return false;
+            }
+            const unsigned char h = (static_cast<unsigned char>(src[i + 1]));
+            const unsigned char l = (static_cast<unsigned char>(src[i + 2]));
+            if (!std::isxdigit(h) || !std::isxdigit(l)) {
+                return false;
+            }
+            int high = std::isdigit(h) ? (h - '0') : (std::toupper(h) - 'A' + 10);
+            int low = std::isdigit(l) ? (l - '0') : (std::toupper(l) - 'A' + 10); // (2)
+            unsigned char decoded = static_cast<unsigned char>((high << 4) | low); // (3)
+            if (decoded < kAsciiSpace && decoded != '\t') {
+                return false; // (4)
+            }
+            out.push_back(static_cast<char>(decoded)); // (5)
+            i += 2;
+        } else {
+            out.push_back(static_cast<char>(chr)); // (6)
+        }
+    }
+    return true;
+}
+
+} // namespace url
+} // namespace utils

--- a/include/utils/url.hpp
+++ b/include/utils/url.hpp
@@ -28,9 +28,9 @@ inline bool decodeStrict(const std::string& src, std::string& out) {
             if (!std::isxdigit(h) || !std::isxdigit(l)) {
                 return false;
             }
-            int high = std::isdigit(h) ? (h - '0') : (std::toupper(h) - 'A' + 10);
-            int low = std::isdigit(l) ? (l - '0') : (std::toupper(l) - 'A' + 10); // (2)
-            unsigned char decoded = static_cast<unsigned char>((high << 4) | low); // (3)
+            const int high = std::isdigit(h) ? (h - '0') : (std::toupper(h) - 'A' + 10);
+            const int low = std::isdigit(l) ? (l - '0') : (std::toupper(l) - 'A' + 10); // (2)
+            const unsigned char decoded = static_cast<unsigned char>((high << 4) | low); // (3)
             if (decoded < kAsciiSpace && decoded != '\t') {
                 return false; // (4)
             }

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -12,6 +12,7 @@
 
 #include "http/response/builder.hpp"
 #include "io/base/FileDescriptor.hpp"
+#include "utils/path.hpp"
 #include "utils/string.hpp"
 
 namespace http {
@@ -24,72 +25,29 @@ Either<IAction*, Response> UploadFileHandler::serve(const Request& request) {
 }
 
 Response UploadFileHandler::serveInternal(const Request& request) const {
-    std::string normalized;
+    // Parser が decode + remove_dot_segments 済みのパスを返す前提
+    const std::string& rel = request.getPath();
 
-    if (!decodeAndNomalizePath(request.getPath(), normalized)) {
-        return ResponseBuilder().status(kStatusBadRequest).build();
+    const std::string& root = docRootConfig_.getRoot();
+    const std::string joined = utils::joinPath(root, rel);
+
+    // スラッシュ正規化（'\\' -> '/', '//' 圧縮）
+    const std::string full = utils::path::normalizeSlashes(joined);
+
+    // ルート配下チェック
+    if (!isPathUnderRoot(full, root)) {
+        return ResponseBuilder().status(kStatusForbidden).build();
     }
 
+    // 親ディレクトリの存在/権限
     const types::Result<types::Unit, HttpStatusCode> dirCheck =
-        checkParentDir(normalized);
-
+        checkParentDir(full);
     if (dirCheck.isErr()) {
         return ResponseBuilder().status(dirCheck.unwrapErr()).build();
     }
 
-    return writeToFile(normalized, request.getBody());
-}
-
-// パストラバーサル攻撃に対する検証
-bool UploadFileHandler::decodeAndNomalizePath(const std::string& rawPath,
-                                              std::string& normalized) const {
-    std::string decoded;
-
-    if (!UploadFileHandler::urlDecodeStrict(rawPath, decoded)) {
-        return false;
-    }
-    while (!decoded.empty() && decoded[0] == '/') {
-        decoded.erase(0, 1);
-    }
-    for (size_t i = 0; i < decoded.size(); ++i) {
-        if (decoded[i] == '\\') {
-            decoded[i] = '/';
-        }
-    }
-    normalized = utils::normalizePath(
-        utils::joinPath(docRootConfig_.getRoot(), decoded));
-    return true;
-}
-
-bool UploadFileHandler::urlDecodeStrict(const std::string& src,
-                                        std::string& out) {
-    out.clear();
-    for (std::size_t i = 0; i < src.size(); ++i) {
-        const char chr = src[i];
-        if (chr == '%') {
-            if (i + 2 >= src.size() ||
-                !std::isxdigit(static_cast<unsigned char>(src[i + 1])) ||
-                !std::isxdigit(static_cast<unsigned char>(src[i + 2]))) {
-                return false;
-            }
-            const int high = std::isdigit(src[i + 1])
-                                 ? src[i + 1] - '0'
-                                 : (std::toupper(src[i + 1]) - 'A' + 10);
-            const int low = std::isdigit(src[i + 2])
-                                ? src[i + 2] - '0'
-                                : (std::toupper(src[i + 2]) - 'A' + 10);
-            const char decoded = static_cast<char>((high << 4) | low);
-            if (static_cast<unsigned char>(decoded) < kAsciiSpace &&
-                decoded != '\t') {
-                return false;
-            }
-            out.push_back(decoded);
-            i += 2;
-        } else {
-            out.push_back(chr);
-        }
-    }
-    return true;
+    // 6) 書き込み
+    return writeToFile(full, request.getBody());
 }
 
 types::Result<types::Unit, HttpStatusCode> UploadFileHandler::checkParentDir(
@@ -118,7 +76,8 @@ types::Result<types::Unit, HttpStatusCode> UploadFileHandler::checkParentDir(
 
 Response UploadFileHandler::writeToFile(const std::string& path,
                                         const std::vector<char>& body) {
-    const int raw_fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    const int raw_fd =
+        open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
     if (raw_fd < 0) {
         return ResponseBuilder().status(kStatusForbidden).build();
     }

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -6,9 +6,11 @@
 #include "context.hpp"
 #include "locationContext.hpp"
 #include "request.hpp"
+#include "utils/path.hpp"
 #include "utils/string.hpp"
 #include "utils/types/either.hpp"
 #include "utils/types/result.hpp"
+#include "utils/url.hpp"
 
 namespace http {
 namespace parse {
@@ -26,9 +28,9 @@ types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     }
     std::istringstream iss(line);
     std::string method;
-    std::string uri;
+    std::string requestTarget;
     std::string version;
-    if (!(iss >> method >> uri >> version)) {
+    if (!(iss >> method >> requestTarget >> version)) {
         return ERR(error::kBadRequest);
     }
     if (method == "GET") {
@@ -40,15 +42,41 @@ types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     } else {
         return ERR(error::kBadMethod);
     }
-    if (uri.length() > kMaxRecommendedRequestLineLength) {
+    if (requestTarget.length() > kMaxRecommendedRequestLineLength) {
         return ERR(error::kUriTooLong);
     }
     const std::size_t kHttpVersionPreFixLen = 8;
     if (version.substr(0, kHttpVersionPreFixLen) != "HTTP/1.1") {
         return ERR(error::kBadHttpVersion);
     }
-    uri_ = uri;
+    const types::Result<types::Unit, error::AppError> norm = 
+        decodeAndNormalizeTarget(requestTarget);
+    if (norm.isErr()) {
+        return norm;
+    }
     version_ = version;
+    return OK(types::Unit());
+}
+
+types::Result<types::Unit, error::AppError>
+RequestParser::decodeAndNormalizeTarget(const std::string& requestTarget) {
+    pathOnly_.clear();
+    queryString_.clear();
+    std::string rawPath = requestTarget;
+    const std::size_t qMark = requestTarget.find('?');
+    if (qMark != std::string::npos) {
+        rawPath = requestTarget.substr(0, qMark);
+        queryString_ = requestTarget.substr(qMark + 1);
+    }
+    std::string decodePath;
+    if (!utils::url::decodeStrict(pathOnly_, decodePath)) {
+        return ERR(error::kBadRequest);
+    }
+    pathOnly_ = utils::path::removeDotSegments(decodePath);
+    if (pathOnly_.empty()) {
+        pathOnly_ = "/";
+    }
+    requestTarget_ = requestTarget;
     return OK(types::Unit());
 }
 
@@ -102,7 +130,7 @@ types::Result<types::Unit, error::AppError> RequestParser::parseBody() {
 }
 
 types::Result<Request, error::AppError> RequestParser::buildRequest() const {
-    const std::string uri = uri_;
+    const std::string uri = requestTarget_;
     const types::Result<const LocationContext*, error::AppError> result =
         chooseLocation(uri);
     if (result.isErr()) {
@@ -110,14 +138,14 @@ types::Result<Request, error::AppError> RequestParser::buildRequest() const {
     }
     const LocationContext* location = result.unwrap();
 
-    std::string queryString;
-    std::string pathOnly = uri;
-    const std::size_t queryMarkPos = uri.find('?');
-    if (queryMarkPos != std::string::npos) {
-        pathOnly = uri.substr(0, queryMarkPos);
-        queryString = uri.substr(queryMarkPos + 1);
-    }
-    const Request req(method_, uri_, headers_, body_, &ctx_->getServer(),
+    // std::string queryString;
+    // std::string pathOnly = uri;
+    // const std::size_t queryMarkPos = uri.find('?');
+    // if (queryMarkPos != std::string::npos) {
+    //     pathOnly = uri.substr(0, queryMarkPos);
+    //     queryString = uri.substr(queryMarkPos + 1);
+    // }
+    const Request req(method_, requestTarget_, pathOnly_, queryString_, headers_, body_, &ctx_->getServer(),
                       result.unwrap());
     return OK(req);
 }

--- a/src/http/request/parse/request_parser.cpp
+++ b/src/http/request/parse/request_parser.cpp
@@ -49,7 +49,7 @@ types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
     if (version.substr(0, kHttpVersionPreFixLen) != "HTTP/1.1") {
         return ERR(error::kBadHttpVersion);
     }
-    const types::Result<types::Unit, error::AppError> norm = 
+    const types::Result<types::Unit, error::AppError> norm =
         decodeAndNormalizeTarget(requestTarget);
     if (norm.isErr()) {
         return norm;
@@ -122,7 +122,7 @@ bool RequestParser::validateTransferEncoding() const {
     return !val.empty() && utils::toLower(val) == "chunked";
 }
 
-// バイナリ対応のため vector<char> に詰め直す    
+// バイナリ対応のため vector<char> に詰め直す
 types::Result<types::Unit, error::AppError> RequestParser::parseBody() {
     const std::string& raw = ctx_->getBody();
     body_.assign(raw.begin(), raw.end());
@@ -130,7 +130,8 @@ types::Result<types::Unit, error::AppError> RequestParser::parseBody() {
 }
 
 types::Result<Request, error::AppError> RequestParser::buildRequest() const {
-    const std::string uri = pathOnly_; const types::Result<const LocationContext*, error::AppError> result =
+    const std::string uri = pathOnly_;
+    const types::Result<const LocationContext*, error::AppError> result =
         chooseLocation(uri);
 
     if (result.isErr()) {
@@ -139,8 +140,8 @@ types::Result<Request, error::AppError> RequestParser::buildRequest() const {
 
     const LocationContext* location = result.unwrap();
 
-    const Request req(method_, requestTarget_, pathOnly_, queryString_, headers_, body_, &ctx_->getServer(),
-                      result.unwrap());
+    const Request req(method_, requestTarget_, pathOnly_, queryString_,
+                      headers_, body_, &ctx_->getServer(), result.unwrap());
     return OK(req);
 }
 
@@ -169,13 +170,17 @@ RequestParser::chooseLocation(const std::string& uri) const {
     return types::err(error::kBadRequest);
 }
 
-    const std::string& RequestParser::getPathOnly() const { return pathOnly_; }
+const std::string& RequestParser::getPathOnly() const { return pathOnly_; }
 
-    const std::string& RequestParser::getQueryString() const { return queryString_; }
-    
-    const std::string& RequestParser::getRequestTarget() const { return requestTarget_; }
-    
-    http::HttpMethod RequestParser::getMethod()const { return method_; }
+const std::string& RequestParser::getQueryString() const {
+    return queryString_;
+}
+
+const std::string& RequestParser::getRequestTarget() const {
+    return requestTarget_;
+}
+
+http::HttpMethod RequestParser::getMethod() const { return method_; }
 
 }  // namespace parse
 }  // namespace http

--- a/src/http/request/request.cpp
+++ b/src/http/request/request.cpp
@@ -5,29 +5,32 @@
 
 namespace http {
 Request::Request(HttpMethod method, const std::string &requestTarget,
+                 const std::string &pathOnly, const std::string &queryString,
                  const RawHeaders &headers, const std::vector<char> &body,
                  const ServerContext *server, const LocationContext *location)
     : method_(method),
       requestTarget_(requestTarget),
+      pathOnly_(pathOnly),
+      queryString_(queryString),
       headers_(headers),
       body_(body),
       server_(server),
       location_(location) {
     httpVersion_ = "HTTP/1.1";
     documentRoot_ = &location_->getDocumentRootConfig();
-    splitTarget();
+    // splitTarget();
 }
 
-void Request::splitTarget() {
-    const std::string::size_type question = requestTarget_.find('?');
-    if (question == std::string::npos) {
-        pathOnly_ = requestTarget_;
-        queryString_.clear();
-    } else {
-        pathOnly_ = requestTarget_.substr(0, question);
-        queryString_ = requestTarget_.substr(question + 1);
-    }
-}
+// void Request::splitTarget() {
+//     const std::string::size_type question = requestTarget_.find('?');
+//     if (question == std::string::npos) {
+//         pathOnly_ = requestTarget_;
+//         queryString_.clear();
+//     } else {
+//         pathOnly_ = requestTarget_.substr(0, question);
+//         queryString_ = requestTarget_.substr(question + 1);
+//     }
+// }
 
 bool Request::operator==(const Request &other) const {
     return method_ == other.method_ && requestTarget_ == other.requestTarget_ &&

--- a/test/http/handler/file/delete_test.cpp
+++ b/test/http/handler/file/delete_test.cpp
@@ -9,11 +9,13 @@ TEST(RedirectHandlerTest, RedirectOldLocation) {
     RedirectHandler handler("/new-location");
     Request request(
         kMethodGet,
-        "/old-location",
-        RawHeaders(),          // 空のヘッダー
-        std::vector<char>(),   // 空のボディ
-        NULL,                  // ServerContext* (C++98ではNULLを使用)
-        NULL                   // LocationContext* (C++98ではNULLを使用)
+        /*requestTarget*/ "/old-location",
+        /*pathOnly*/      "/old-location",
+        /*queryString*/   "",
+        /*headers*/       RawHeaders(),
+        /*body*/          std::vector<char>(),
+        /*server*/        NULL,     // C++98 なら NULL
+        /*location*/      NULL
     );
     Either<IAction *, Response> result = handler.serve(request);
     ASSERT_TRUE(result.isRight());

--- a/test/http/handler/file/redirect_test.cpp
+++ b/test/http/handler/file/redirect_test.cpp
@@ -16,12 +16,14 @@ TEST(RedirectHandlerTest, RedirectsToDestination) {
     const LocationContext* location = NULL;
     
     Request request(
-        kMethodGet,           // HttpMethod method
-        "/old-location",      // const std::string &requestTarget
-        headers,              // const RawHeaders &headers
-        body,                 // const std::vector<char> &body
-        server,               // const ServerContext *server
-        location              // const LocationContext *location
+        kMethodGet,            // HttpMethod
+        "/old-location",       // requestTarget（生）
+        "/old-location",       // pathOnly（正規化済み想定）
+        "",                    // queryString
+        headers,               // headers
+        body,                  // body
+        server,                // ServerContext*
+        location               // LocationContext*
     );
     
     Either<IAction *, Response> result = handler.serve(request);

--- a/test/http/handler/file/static_test.cpp
+++ b/test/http/handler/file/static_test.cpp
@@ -33,7 +33,26 @@ protected:
     Request createRequest(const std::string& target) {
         RawHeaders headers;
         std::vector<char> body;
-        return Request(kMethodGet, target, headers, body, server_, location_);
+
+        // request-target を path と query に分割
+        std::string pathOnly = target;
+        std::string queryString;
+        const std::size_t qm = target.find('?');
+        if (qm != std::string::npos) {
+            pathOnly = target.substr(0, qm);
+            queryString = target.substr(qm + 1);
+        }
+        // テスト入力は既に正規化済み想定（"/", "/dir1", "/file.txt" など）
+        return Request(
+            kMethodGet,    // method
+            target,        // requestTarget (raw)
+            pathOnly,      // pathOnly (normalized想定)
+            queryString,   // queryString
+            headers,       // headers
+            body,          // body
+            server_,       // server
+            location_      // location
+        );
     }
     
     DocumentRootConfig docRootConfig_;

--- a/test/http/handler/router/middleware/error_page_test.cpp
+++ b/test/http/handler/router/middleware/error_page_test.cpp
@@ -16,15 +16,27 @@
 static http::Request makeRequest(http::HttpMethod m, const std::string& target,
                                  ServerContext& server,
                                  LocationContext& location) {
-    std::string path = target, query;
-    if (std::size_t p = target.find('?'); p != std::string::npos) {
-        path = target.substr(0, p);
-        query = target.substr(p + 1);
+    std::string pathOnly = target;
+    std::string queryString;
+    std::size_t pos = target.find('?');
+    if (pos != std::string::npos) {
+        pathOnly = target.substr(0, pos);
+        queryString = target.substr(pos + 1);
     }
+
     RawHeaders headers;
     std::vector<char> body;
-    return http::Request(m, target, headers, body, &server,
-                         &location);
+
+    return http::Request(
+        m,
+        /*requestTarget*/ target,
+        /*pathOnly*/      pathOnly,
+        /*queryString*/   queryString,
+        /*headers*/       headers,
+        /*body*/          body,
+        /*server*/        &server,
+        /*location*/      &location
+    );
 }
 
 class MockNextHandler : public http::IHandler {

--- a/test/http/handler/router/middleware/logger_test.cpp
+++ b/test/http/handler/router/middleware/logger_test.cpp
@@ -19,14 +19,27 @@
 static http::Request makeRequest(http::HttpMethod m, const std::string& target,
                                  ServerContext& server,
                                  LocationContext& location) {
-    std::string path = target, query;
-    if (std::size_t p = target.find('?'); p != std::string::npos) {
-        path = target.substr(0, p);
-        query = target.substr(p + 1);
+    std::string pathOnly = target;
+    std::string queryString;
+    std::size_t pos = target.find('?');
+    if (pos != std::string::npos) {
+        pathOnly = target.substr(0, pos);
+        queryString = target.substr(pos + 1);
     }
+
     RawHeaders headers;
     std::vector<char> body;
-    return http::Request(m, target, headers, body, &server, &location);
+
+    return http::Request(
+        m,
+        /*requestTarget*/ target,
+        /*pathOnly*/      pathOnly,
+        /*queryString*/   queryString,
+        /*headers*/       headers,
+        /*body*/          body,
+        /*server*/        &server,
+        /*location*/      &location
+    );
 }
 namespace http {
 

--- a/test/http/handler/router/router_test.cpp
+++ b/test/http/handler/router/router_test.cpp
@@ -31,14 +31,22 @@ static void splitTarget(const std::string& target, std::string& pathOnly,
 static http::Request makeRequest(http::HttpMethod m, const std::string& target,
                                  ServerContext& server,
                                  LocationContext& location) {
-    std::string path = target, query;
-    if (std::size_t p = target.find('?'); p != std::string::npos) {
-        path = target.substr(0, p);
-        query = target.substr(p + 1);
-    }
+    std::string pathOnly, queryString;
+    splitTarget(target, pathOnly, queryString);
+
     RawHeaders headers;
     std::vector<char> body;
-    return http::Request(m, target, headers, body, &server, &location);
+
+    return http::Request(
+        m,
+        /*requestTarget*/ target,
+        /*pathOnly*/      pathOnly,
+        /*queryString*/   queryString,
+        /*headers*/       headers,
+        /*body*/          body,
+        /*server*/        &server,
+        /*location*/      &location
+    );
 }
 
 namespace {

--- a/test/http/virtual_server_test.cpp
+++ b/test/http/virtual_server_test.cpp
@@ -72,9 +72,32 @@ static LocationContext MakeLoc(const std::string& path, bool allow_get,
 static http::Request MakeReq(http::HttpMethod m, const std::string& target,
                              const ServerContext* sc,
                              const LocationContext* lc) {
-    RawHeaders headers;      // 型は request.hpp の定義に依存（空でOK）
-    std::vector<char> body;  // 空でOK
-    return http::Request(m, target, headers, body, sc, lc);
+    RawHeaders headers;
+    std::vector<char> body;
+
+    // request-target を path と query に分割
+    std::string pathOnly = target;
+    std::string queryString;
+    const std::size_t qm = target.find('?');
+    if (qm != std::string::npos) {
+        pathOnly = target.substr(0, qm);
+        queryString = target.substr(qm + 1);
+    }
+
+    // Router/Handler は正規化済み pathOnly を見る想定なら、
+    // テストでは簡易にそのまま渡してOK（"/upload" 等しか使っていないため）。
+    // 必要ならここで removeDotSegments/decodeStrict を呼ぶ。
+
+    return http::Request(
+        m,
+        /*requestTarget*/ target,
+        /*pathOnly*/      pathOnly,
+        /*queryString*/   queryString,
+        headers,
+        body,
+        sc,
+        lc
+    );
 }
 
 // コンストラクタが ServerContext を保持しているか（既存の基本テスト）


### PR DESCRIPTION
## 概要 / Overview

- requestで受け取ったurlの正当性チェックをUploadFileHandlerからRequestParserに移した

## 該当する issue

- #112 

## 変更内容

RequestParseerに、requestTargetを判定する関数decodeAndNormalizeTarget()を加えました
```
types::Result<types::Unit, error::AppError> RequestParser::parseRequestLine() {
    const std::string& line = ctx_->getRequestLine();
    if (!utils::endsWith(line, "\r\n")) {
        return ERR(error::kBadRequest);
    }
    std::istringstream iss(line);
    std::string method;
    std::string requestTarget;
    std::string version;
    if (!(iss >> method >> requestTarget >> version)) {
        return ERR(error::kBadRequest);
    }
    if (method == "GET") {
        method_ = kMethodGet;
    } else if (method == "POST") {
        method_ = kMethodPost;
    } else if (method == "DELETE") {
        method_ = kMethodDelete;
    } else {
        return ERR(error::kBadMethod);
    }
    if (requestTarget.length() > kMaxRecommendedRequestLineLength) {
        return ERR(error::kUriTooLong);
    }
    const std::size_t kHttpVersionPreFixLen = 8;
    if (version.substr(0, kHttpVersionPreFixLen) != "HTTP/1.1") {
        return ERR(error::kBadHttpVersion);
    }
    const types::Result<types::Unit, error::AppError> norm =
        decodeAndNormalizeTarget(requestTarget);
    if (norm.isErr()) {
        return norm;
    }
    version_ = version;
    return OK(types::Unit());
}

types::Result<types::Unit, error::AppError>
RequestParser::decodeAndNormalizeTarget(const std::string& requestTarget) {
    pathOnly_.clear();
    queryString_.clear();
    std::string rawPath = requestTarget;
    const std::size_t qMark = requestTarget.find('?');
    if (qMark != std::string::npos) {
        rawPath = requestTarget.substr(0, qMark);
        queryString_ = requestTarget.substr(qMark + 1);
    }
    std::string decodePath;
    if (!utils::url::decodeStrict(rawPath, decodePath)) {
        return ERR(error::kBadRequest);
    }
    pathOnly_ = utils::path::removeDotSegments(decodePath);
    if (pathOnly_.empty()) {
        pathOnly_ = "/";
    }
    requestTarget_ = requestTarget;
    return OK(types::Unit());
}

```

utils/path.hppに以下を実装
1. compressDecments() 
　　ドットセグメント削除
　　'/'圧縮など
2. removeDotSegments()
　　RequestParserで使用するurlチェック
3. normalizeShashes()
　　２以外で使うスラッシュ正規化

```
#pragma once

#include <iostream>
#include <sstream>
#include <vector>

namespace utils {
namespace path {

inline void compressSegmentCore(const std::string& inString,
                                std::vector<std::string>& segs);

// 共通コア：ドットセグメント削除＆連続 '/' 圧縮
//  - keepAbsolute: 入力が絶対パス（先頭 '/'）なら出力でも保持
//  - keepTrailingSlash: 入力が末尾 '/' なら可能なら保持
inline std::string compressSegments(const std::string& inString,
                                    bool keepAbsolute, bool keepTrailingSlash) {
    const bool isAbs = !inString.empty() && inString[0] == '/';
    const bool hadTrailing =
        !inString.empty() && inString[inString.size() - 1] == '/';

    std::vector<std::string> segs;
    // 圧縮
    compressSegmentCore(inString, segs);
    // 再構築
    std::string out;
    if (keepAbsolute && isAbs) {
        out.push_back('/');
    }
    for (std::size_t i = 0; i < segs.size(); ++i) {
        out += segs[i];
        if (i + 1 != segs.size()) {
            out.push_back('/');
        }
    }
    const bool needKeepTrailing = keepTrailingSlash && hadTrailing;
    const bool hasPathContent = (keepAbsolute && isAbs) || !segs.empty();
    if (needKeepTrailing && hasPathContent) {
        if (!out.empty() && out[out.size() - 1] != '/') {
            out.push_back('/');
        }
    }
    if (out.empty() && keepAbsolute && isAbs) {
        out = "/";
    }
    return out;
}

inline void compressSegmentCore(const std::string& inString,
                                std::vector<std::string>& segs) {
    segs.clear();
    const std::string::size_type stringSize = inString.size();
    static const int MARGIN = 8;
    if (segs.capacity() < static_cast<std::size_t>(MARGIN)) {
        segs.reserve(MARGIN);
    }
    std::string::size_type i = 0;
    while (i < stringSize) {
        while (i < stringSize && inString[i] == '/') {
            ++i;
        }
        std::string::size_type j = i;
        while (j < stringSize && inString[j] != '/') {
            ++j;
        }
        if (j > i) {  // セグメントが空でなければ
            const std::string seg = inString.substr(i, j - i);
            if (seg == ".") {
                // ignore
            } else if (seg == "..") {
                if (!segs.empty()) {
                    segs.pop_back();
                } else {
                    // ignore
                }
            } else {
                segs.push_back(seg);
            }
        }
        i = j;
    }
}

// 使い方1
// RFC 3986 §5.2.4 準拠の dot-segment 除去
// URL の相対解決や正規化の一部として使う
// "." / ".." セグメントを削除
// 事前条件: "%2e" 等は decode_strict 済みで '.' にデコードされていること
inline std::string removeDotSegments(const std::string& decodedPath) {
    return compressSegments(decodedPath, /*keepAbsolute=*/true,
                            /*keepTrailingSlash=*/true);
}

// 使い方2
// ファイルシステム用の「スラッシュ正規化」
//  - バックスラッシュはスラッシュに変換
//  - その後に dot-segment 除去＆連続 '/' 圧縮
inline std::string normalizeSlashes(const std::string& pathLike) {
    std::string tmp;
    tmp.reserve(pathLike.size());

    for (std::size_t i = 0; i < pathLike.size(); ++i) {
        char chr = pathLike[i];
        if (chr == '\\') {
            chr = '/';
        }
        tmp.push_back(chr);
    }
    return compressSegments(tmp, /*keepAbsolute=*/true,
                            /*keepTrailingSlash=*/true);
}

}  // namespace path
}  // namespace utils

```

utils/url.hppに以下を実装
```
#pragma once

#include <iostream>

namespace utils {
namespace url {

    // 厳密な %XX デコード（不正なエンコードや危険な制御文字を拒否）
    // 成功: true（out に上書き） / 失敗: false（out は未定義）
    // ‘%’が来たら
    // 1) エスケープシーケンスの妥当性チェック
    // 2) 16進文字を数値に変換
    // 3) バイトに復元
    // 4) ASCII 制御文字かどうか検証
    // 5) 出力に追加
    // 6) '%' 以外はそのまま出力
inline bool decodeStrict(const std::string& src, std::string& out) {
    static const unsigned char kAsciiSpace = 0x20;
    out.clear();
    for (std::size_t i = 0; i < src.size(); ++i) {
        const unsigned char chr = static_cast<unsigned char>(src[i]);
        if (chr == '%') {
            if (i + 2 >= src.size()) {
                return false;
            }
            const unsigned char h = (static_cast<unsigned char>(src[i + 1]));
            const unsigned char l = (static_cast<unsigned char>(src[i + 2]));
            if (!std::isxdigit(h) || !std::isxdigit(l)) {
                return false;
            }
            const int high = std::isdigit(h) ? (h - '0') : (std::toupper(h) - 'A' + 10);
            const int low = std::isdigit(l) ? (l - '0') : (std::toupper(l) - 'A' + 10); // (2)
            const unsigned char decoded = static_cast<unsigned char>((high << 4) | low); // (3)
            if (decoded < kAsciiSpace && decoded != '\t') {
                return false; // (4)
            }
            out.push_back(static_cast<char>(decoded)); // (5)
            i += 2;
        } else {
            out.push_back(static_cast<char>(chr)); // (6)
        }
    }
    return true;
}

} // namespace url
} // namespace utils

```

## 影響範囲
- RequestParser
- UploadFileHandler
- Requestを使うクラス

＊Requestに正規化されたpathOnly_が渡るようにしました

## その他
