### PR TITLE
121 bug fix config

### DIFF
--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -20,6 +20,7 @@ server {
     allow_method GET POST DELETE;
 
     root ./www/user_uploads;
+    enable_upload ON;
     autoindex ON;
   }
 
@@ -38,7 +39,7 @@ server {
     index index.html;
   }
 
-  location_back .php {
+  location .php {
     is_cgi ON;
     root ./nginx/cgi_bins;
   }
@@ -53,7 +54,7 @@ server {
     index index.html;
   }
 
-  location_back .php {
+  location .php {
     is_cgi ON;
     root ./nginx/cgi_bins;
   }

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  host localhost;
+  # host localhost;
   server_names www.webserv.com webserv.com;
     error_page 500 500.html;
     error_page 403 403.html;

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -31,7 +31,7 @@ server {
 
 server {
   listen 80;
-  host localhost;
+  host local;
   server_names www.webserv.com webserv.com;
 
   location / {

--- a/include/config/context/documentRootConfig.hpp
+++ b/include/config/context/documentRootConfig.hpp
@@ -14,11 +14,13 @@ class DocumentRootConfig {
     void setIndex(const std::string& index);
     void setAutoIndex(OnOff autoIndex);
     void setCgiExtensions(OnOff cgiExtensions);
+    void setEnabelUpload(OnOff enableUpload);
 
     const std::string& getRoot() const;
     const std::string& getIndex() const;
     OnOff getAutoIndex() const;
     OnOff getCgiExtensions() const;
+    OnOff getEnableUpload() const;
 
     bool isAutoindexEnabled() const;
 
@@ -27,4 +29,5 @@ class DocumentRootConfig {
     std::string index_;
     OnOff autoIndex_;
     OnOff cgiExtensions_;
+    OnOff enableUpload_;
 };

--- a/include/config/parser.hpp
+++ b/include/config/parser.hpp
@@ -22,7 +22,7 @@ class ConfigParser {
 
    private:
     static const int FUNC_SERVER_SIZE = 6;
-    static const int FUNC_LOCATION_SIZE = 6;
+    static const int FUNC_LOCATION_SIZE = 7;
     typedef void (ConfigParser::*funcServerPtr)(ServerContext& server,
                                                 size_t& index);
     static funcServerPtr funcServer_[FUNC_SERVER_SIZE];
@@ -51,5 +51,6 @@ class ConfigParser {
     void setAutoIndex_(LocationContext& location, size_t& index);
     void setIsCgi_(LocationContext& location, size_t& index);
     void setRedirect_(LocationContext& location, size_t& index);
+    void setEnableUpload_(LocationContext& location, size_t& index);
     std::string incrementAndCheckSize_(size_t& index);
 };

--- a/include/config/token.hpp
+++ b/include/config/token.hpp
@@ -16,6 +16,7 @@ enum TokenType {
     AUTOINDEX,
     IS_CGI,
     REDIRECT,
+    ENABLE_UPLOAD,
     SERVER,
     VALUE,
     BRACE

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,11 +1,24 @@
 #include "config/config.hpp"
 
 #include <cstddef>
+#include <string>
 
 #include "data.hpp"
 #include "documentRootConfig.hpp"
 #include "locationContext.hpp"
 #include "serverContext.hpp"
+
+namespace {
+static std::string normalizeHostKey(const std::string& host) {
+    if (host.empty()) {
+        return "127.0.0.1";
+    }
+    if (host == "localhost") {
+        return "127.0.0.1";
+    }
+    return host;
+}
+} // namespace
 
 struct ConfigServerValueErrorEraser {
    private:
@@ -23,25 +36,27 @@ struct ConfigServerValueErrorEraser {
 
 struct ConfigServerDuplicateErrorEraser {
    private:
-    std::vector<int>* seenListenValue;
+    std::vector<std::pair<std::string, int> >* seenHostPlusListen;
 
    public:
-    explicit ConfigServerDuplicateErrorEraser(std::vector<int>* seen)
-        : seenListenValue(seen) {}
+    explicit ConfigServerDuplicateErrorEraser(
+        std::vector<std::pair<std::string, int> >* seen)
+        : seenHostPlusListen(seen) {}
 
     bool operator()(const ServerContext& server) {
         const int listen = server.getListen();
+        const std::string hostKey = normalizeHostKey(server.getHost());
 
-        for (std::vector<int>::iterator it = seenListenValue->begin();
-             it != seenListenValue->end(); ++it) {
-            if (*it == listen) {
+        for (std::vector<std::pair<std::string, int> >::iterator it = seenHostPlusListen->begin();
+             it != seenHostPlusListen->end(); ++it) {
+            if (it->second == listen && it->first == hostKey) {
                 std::cerr << "[ server removed: listen port "
                              "duplicate error ]"
                           << std::endl;
                 return (true);
             }
         }
-        seenListenValue->push_back(listen);
+        seenHostPlusListen->push_back(std::make_pair(hostKey, listen));
         return (false);
     }
 };
@@ -106,7 +121,7 @@ bool Config::checkAndEraseLocationNode(const ServerContext& server) {
 }
 
 void Config::removeDuplicateListenServers(std::vector<ServerContext>& servers) {
-    std::vector<int> seenListenValue;
+    std::vector<std::pair<std::string, int> > seenListenValue;
 
     servers.erase(
         std::remove_if(servers.begin(), servers.end(),

--- a/src/config/context/documentRootConfig.cpp
+++ b/src/config/context/documentRootConfig.cpp
@@ -1,7 +1,7 @@
 #include "documentRootConfig.hpp"
 
 DocumentRootConfig::DocumentRootConfig()
-    : index_("index.html"), autoIndex_(OFF), cgiExtensions_(OFF) {
+    : index_("index.html"), autoIndex_(OFF), cgiExtensions_(OFF), enableUpload_(OFF) {
 }
 
 DocumentRootConfig::~DocumentRootConfig() {
@@ -23,6 +23,10 @@ void DocumentRootConfig::setCgiExtensions(OnOff cgiExtensions) {
     cgiExtensions_ = cgiExtensions;
 }
 
+void DocumentRootConfig::setEnabelUpload(OnOff enableUpload) {
+    enableUpload_ = enableUpload;
+}
+
 const std::string& DocumentRootConfig::getRoot() const {
     return root_;
 }
@@ -37,6 +41,10 @@ OnOff DocumentRootConfig::getAutoIndex() const {
 
 OnOff DocumentRootConfig::getCgiExtensions() const {
     return cgiExtensions_;
+}
+
+OnOff DocumentRootConfig::getEnableUpload() const {
+    return enableUpload_;
 }
 
 bool DocumentRootConfig::isAutoindexEnabled() const {

--- a/src/config/context/serverContext.cpp
+++ b/src/config/context/serverContext.cpp
@@ -1,7 +1,7 @@
 #include "serverContext.hpp"
 
 ServerContext::ServerContext(const std::string& text)
-    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE) {
+    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("127.0.0.1") {
     // std::map<http::HttpStatusCode, std::string> errPage;
     // errPage.insert(std::make_pair(http::kStatusNotFound, "404.html"));
     // this->errorPage_.push_back(errPage);

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -22,7 +22,8 @@ void (ConfigParser::* ConfigParser::funcLocation_[FUNC_LOCATION_SIZE])(
     LocationContext&, size_t&) = {
     &ConfigParser::setRoot_,  &ConfigParser::setMethod_,
     &ConfigParser::setIndex_, &ConfigParser::setAutoIndex_,
-    &ConfigParser::setIsCgi_, &ConfigParser::setRedirect_};
+    &ConfigParser::setIsCgi_, &ConfigParser::setRedirect_,
+    &ConfigParser::setEnableUpload_};
 
 ConfigParser::ConfigParser(ConfigTokenizer& tokenizer, const std::string& confFile)
     : tokens_(tokenizer.getTokens()), depth_(0), confFile_(confFile) {
@@ -47,7 +48,7 @@ void ConfigParser::makeVectorServer_() {
                          tokens_[i].getLineNumber());
             }
             addServer_(i);
-        } else if ((type >= LISTEN && type <= REDIRECT) && this->depth_ == 0) {
+        } else if ((type >= LISTEN && type <= ENABLE_UPLOAD) && this->depth_ == 0) {
             throwErr(this->tokens_[i].getText(), ": Syntax error: line",
                      tokens_[i].getLineNumber());
         } else {
@@ -178,7 +179,7 @@ void ConfigParser::addLocation_(ServerContext& server, size_t& index) {
                 server.getLocation().push_back(location);
                 break;
             }
-        } else if (type >= ROOT && type <= REDIRECT) {
+        } else if (type >= ROOT && type <= ENABLE_UPLOAD) {
             (this->*funcLocation_[type - FUNC_SERVER_SIZE])(location, index);
         } else {
             continue;
@@ -295,6 +296,22 @@ void ConfigParser::setRedirect_(LocationContext& location, size_t& index) {
         throwErr(this->tokens_[index].getText(),
                  ": Redirect value error: line ",
                  this->tokens_[index].getLineNumber());
+    }
+}
+
+void ConfigParser::setEnableUpload_(LocationContext& location, size_t& index) {
+    const std::string select = incrementAndCheckSize_(index);
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
+
+    if (this->tokens_[index].getType() == VALUE) {
+        if (select == "ON") {
+            documentRootConfig.setEnabelUpload(ON);
+        } else if (select == "OFF") {
+            documentRootConfig.setEnabelUpload(OFF);
+        } else {
+            throwErr(select, ": Unknown select error: line ",
+                     this->tokens_[index].getLineNumber());
+        }
     }
 }
 

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -114,9 +114,6 @@ void ConfigParser::setHost_(ServerContext& server, size_t& index) {
 
     if (this->tokens_[index].getType() == VALUE) {
         server.setHost(hostName);
-    } else {
-        throwErr(hostName, ": Host value error: line",
-                 this->tokens_[index].getLineNumber());
     }
 }
 

--- a/src/config/testPrint.cpp
+++ b/src/config/testPrint.cpp
@@ -51,6 +51,8 @@ void Config::printLocation(const ServerContext& server) {
                   << std::endl;
         std::cout << "     |- is_cgi: " << documentRootConfig.getCgiExtensions()
                   << std::endl;
+        std::cout << "     |- enabel_upload: " << documentRootConfig.getEnableUpload()
+                  << std::endl;
         if (!location[k].getRedirect().empty()) {
             std::cout << "     |- redirect: " << location[k].getRedirect()
                       << std::endl;

--- a/src/config/token.cpp
+++ b/src/config/token.cpp
@@ -38,7 +38,7 @@ void Token::setType_(const std::string& text) {
         tokenMap.insert(std::make_pair("root", ROOT));
         tokenMap.insert(std::make_pair("server", SERVER));
         tokenMap.insert(std::make_pair("location", LOCATION));
-        tokenMap.insert(std::make_pair("location_back", LOCATION));
+        // tokenMap.insert(std::make_pair("location_back", LOCATION));
         tokenMap.insert(std::make_pair("error_page", ERR_PAGE));
         tokenMap.insert(std::make_pair("listen", LISTEN));
         tokenMap.insert(std::make_pair("host", HOST));
@@ -49,6 +49,7 @@ void Token::setType_(const std::string& text) {
         tokenMap.insert(std::make_pair("autoindex", AUTOINDEX));
         tokenMap.insert(std::make_pair("is_cgi", IS_CGI));
         tokenMap.insert(std::make_pair("redirect", REDIRECT));
+        tokenMap.insert(std::make_pair("enable_upload", ENABLE_UPLOAD));
     }
     const std::map<std::string, TokenType>::const_iterator it =
         tokenMap.find(text);
@@ -58,7 +59,7 @@ void Token::setType_(const std::string& text) {
         this->type_ = it->second;
     } else if (this->position_ == BEGINNING) {
         throw(std::runtime_error(
-            text + ": Syntax error : line " +
+            text + ": Syntax error6 : line " +
             ConfigTokenizer::numberToStr(this->lineNumber_)));
     } else {
         this->type_ = VALUE;

--- a/src/http/handler/file/cgi.cpp
+++ b/src/http/handler/file/cgi.cpp
@@ -21,8 +21,8 @@ Response CgiHandler::serveInternal(const Request& req) const {
         return ResponseBuilder().status(kStatusNotFound).build();
     }
 
-    std::string joined = utils::joinPath(docRootConfig_.getRoot(), scriptPath);
-    std::string realScriptPath = utils::normalizePath(joined);
+    const std::string joined = utils::joinPath(docRootConfig_.getRoot(), scriptPath);
+    const std::string realScriptPath = utils::normalizePath(joined);
 
     std::vector<std::string> env;
     buildCgiEnv(req, scriptPath, &pathInfo, &env);

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -25,6 +25,11 @@ Either<IAction*, Response> UploadFileHandler::serve(const Request& request) {
 }
 
 Response UploadFileHandler::serveInternal(const Request& request) const {
+    // このロケーションでアップロードが許可されていなければ拒否
+    if (!docRootConfig_.getEnableUpload()) {
+        return ResponseBuilder().status(kStatusForbidden).build();
+    }
+
     // Parser が decode + remove_dot_segments 済みのパスを返す前提
     const std::string& rel = request.getPath();
 

--- a/test/http/handler/file/upload_test.cpp
+++ b/test/http/handler/file/upload_test.cpp
@@ -54,6 +54,7 @@ protected:
 TEST_F(UploadFileHandlerTest, UploadsFileSuccessfully) {
     DocumentRootConfig config;
     config.setRoot(tempDir);
+    config.setEnabelUpload(ON);
 
     UploadFileHandler handler(config);
 
@@ -98,6 +99,7 @@ TEST_F(UploadFileHandlerTest, Returns403IfFileCannotBeOpened) {
 TEST_F(UploadFileHandlerTest, Returns404IfDirectoryDoesNotExist) {
     DocumentRootConfig config;
     config.setRoot("nonexistent_dir");
+    config.setEnabelUpload(ON);
     UploadFileHandler handler(config);
 
     RawHeaders headers;


### PR DESCRIPTION
## 概要 / Overview

- config設定ファイルの仕様変更
1. DocumentRootConfigクラスに enableUplead_; 変数を加えました
2. hostのデフォルトを設定しました
3. 設定ファイルのserverブロック重複判定を変更しました

## 該当する issue

- #121 

## 変更内容

1. DocumentRootConfigにenableUplate_を加えました
　・デフォルトはOFF(=0)に設定してい
　・UploadHandlerにエラー処理を加えました
```
Response UploadFileHandler::serveInternal(const Request& request) const {
    // このロケーションでアップロードが許可されていなければ拒否 <-- 加えた部分
    if (!docRootConfig_.getEnableUpload()) {
        return ResponseBuilder().status(kStatusForbidden).build();
    }

    // Parser が decode + remove_dot_segments 済みのパスを返す前提
    const std::string& rel = request.getPath();

    const std::string& root = docRootConfig_.getRoot();
    const std::string joined = utils::joinPath(root, rel);

    // スラッシュ正規化（'\\' -> '/', '//' 圧縮）
    const std::string full = utils::path::normalizeSlashes(joined);

    // ルート配下チェック
    if (!utils::path::isPathUnderRoot(root, full)) {
        return ResponseBuilder().status(kStatusForbidden).build();
    }

    // 親ディレクトリの存在/権限
    const types::Result<types::Unit, HttpStatusCode> dirCheck =
        checkParentDir(full);
    if (dirCheck.isErr()) {
        return ResponseBuilder().status(dirCheck.unwrapErr()).build();
    }

    // 6) 書き込み
    return writeToFile(full, request.getBody());
}
```

2. hostのデフォルトを"127.0.0.1"に変更しました

3. serverブロックの重複判定をhost+listenに変更しました
```
config.cpp
namespace {
static std::string normalizeHostKey(const std::string& host) {
    if (host.empty()) {
        return "127.0.0.1";
    }
    if (host == "localhost") {
        return "127.0.0.1";
    }
    return host;
}
} // namespace

struct ConfigServerDuplicateErrorEraser {
   private:
    std::vector<std::pair<std::string, int> >* seenHostPlusListen; <-- std::vector<int>から変更

   public:
    explicit ConfigServerDuplicateErrorEraser(
        std::vector<std::pair<std::string, int> >* seen)
        : seenHostPlusListen(seen) {}

    bool operator()(const ServerContext& server) {
        const int listen = server.getListen();
        const std::string hostKey = normalizeHostKey(server.getHost());

        for (std::vector<std::pair<std::string, int> >::iterator it = seenHostPlusListen->begin();
             it != seenHostPlusListen->end(); ++it) {
            if (it->second == listen && it->first == hostKey) {　<-- 重複条件を変更
                std::cerr << "[ server removed: listen port "
                             "duplicate error ]"
                          << std::endl;
                return (true);
            }
        }
        seenHostPlusListen->push_back(std::make_pair(hostKey, listen));
        return (false);
    }
};

void Config::removeDuplicateListenServers(std::vector<ServerContext>& servers) {
    std::vector<std::pair<std::string, int> > seenListenValue; <-- 呼び出し側も変更

    servers.erase(
        std::remove_if(servers.begin(), servers.end(),
                       ConfigServerDuplicateErrorEraser(&seenListenValue)),
        servers.end());
}
```

## 影響範囲
- config/下のDucumentRootConfigが関わるファイル
- http/response/handler/upload.cpp
## その他
