### PR TITLE
122 bug fix cgi handler

### DIFF
--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -20,6 +20,7 @@ server {
     allow_method GET POST DELETE;
 
     root ./www/user_uploads;
+    enable_upload ON;
     autoindex ON;
   }
 
@@ -38,7 +39,7 @@ server {
     index index.html;
   }
 
-  location_back .php {
+  location .php {
     is_cgi ON;
     root ./nginx/cgi_bins;
   }
@@ -53,7 +54,7 @@ server {
     index index.html;
   }
 
-  location_back .php {
+  location .php {
     is_cgi ON;
     root ./nginx/cgi_bins;
   }

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  host localhost;
+  # host localhost;
   server_names www.webserv.com webserv.com;
     error_page 500 500.html;
     error_page 403 403.html;

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -31,7 +31,7 @@ server {
 
 server {
   listen 80;
-  host localhost;
+  host local;
   server_names www.webserv.com webserv.com;
 
   location / {

--- a/include/config/context/documentRootConfig.hpp
+++ b/include/config/context/documentRootConfig.hpp
@@ -14,11 +14,13 @@ class DocumentRootConfig {
     void setIndex(const std::string& index);
     void setAutoIndex(OnOff autoIndex);
     void setCgiExtensions(OnOff cgiExtensions);
+    void setEnabelUpload(OnOff enableUpload);
 
     const std::string& getRoot() const;
     const std::string& getIndex() const;
     OnOff getAutoIndex() const;
     OnOff getCgiExtensions() const;
+    OnOff getEnableUpload() const;
 
     bool isAutoindexEnabled() const;
 
@@ -27,4 +29,5 @@ class DocumentRootConfig {
     std::string index_;
     OnOff autoIndex_;
     OnOff cgiExtensions_;
+    OnOff enableUpload_;
 };

--- a/include/config/context/documentRootConfig.hpp
+++ b/include/config/context/documentRootConfig.hpp
@@ -14,7 +14,7 @@ class DocumentRootConfig {
     void setIndex(const std::string& index);
     void setAutoIndex(OnOff autoIndex);
     void setCgiExtensions(OnOff cgiExtensions);
-    void setEnabelUpload(OnOff enableUpload);
+    void setEnableUpload(OnOff enableUpload);
 
     const std::string& getRoot() const;
     const std::string& getIndex() const;

--- a/include/config/parser.hpp
+++ b/include/config/parser.hpp
@@ -22,7 +22,7 @@ class ConfigParser {
 
    private:
     static const int FUNC_SERVER_SIZE = 6;
-    static const int FUNC_LOCATION_SIZE = 6;
+    static const int FUNC_LOCATION_SIZE = 7;
     typedef void (ConfigParser::*funcServerPtr)(ServerContext& server,
                                                 size_t& index);
     static funcServerPtr funcServer_[FUNC_SERVER_SIZE];
@@ -51,5 +51,6 @@ class ConfigParser {
     void setAutoIndex_(LocationContext& location, size_t& index);
     void setIsCgi_(LocationContext& location, size_t& index);
     void setRedirect_(LocationContext& location, size_t& index);
+    void setEnableUpload_(LocationContext& location, size_t& index);
     std::string incrementAndCheckSize_(size_t& index);
 };

--- a/include/config/token.hpp
+++ b/include/config/token.hpp
@@ -16,6 +16,7 @@ enum TokenType {
     AUTOINDEX,
     IS_CGI,
     REDIRECT,
+    ENABLE_UPLOAD,
     SERVER,
     VALUE,
     BRACE

--- a/include/http/actions/cgiTask.hpp
+++ b/include/http/actions/cgiTask.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "action/action.hpp"
+#include <string>
+#include <vector>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace http {
+class CgiHandler;
+
+class CgiTask : public IAction {
+   public:
+    CgiTask(pid_t pid, int rfd, int wfd,
+            const std::vector<char>& stdinBody,
+            const CgiHandler* owner);
+    virtual ~CgiTask();
+    virtual void execute(ActionContext& ctx);
+
+   private:
+    void registerIfNeeded(ActionContext& ctx);
+    void handleEvent(int fd, unsigned int event, ActionContext& ctx);
+    void readOnce();
+    void writeOnce(ActionContext& ctx);
+    void closeFd(int fd);
+    void reapChild();
+    void finishIfDone(ActionContext& ctx);
+
+   private:
+    pid_t pid_;
+    int rfd_;
+    int wfd_;
+    const char* wPtr_;
+    ssize_t wRemain_;
+    bool rClosed_;
+    bool wClosed_;
+    bool registered_;
+    bool reaped_;
+    int exitCode_;
+    std::string cgiOut_;
+    const CgiHandler* owner_;
+};
+} // namespace http

--- a/include/http/handler/file/cgi.hpp
+++ b/include/http/handler/file/cgi.hpp
@@ -5,16 +5,23 @@
 
 namespace http {
 
+    struct CgiSpawn {
+        pid_t pid;
+        int rfd; // 子->親 (親が読む)
+        int wfd; // 親->子 (親が書く)
+    };
+
 class CgiHandler : public IHandler {
    public:
     explicit CgiHandler(const DocumentRootConfig &docRootConfig);
     Either<IAction *, Response> serve(const Request &req);
+    Response parseCgiAndBuildResponse(const std::string& cgiOut) const;
 
    private:
     DocumentRootConfig docRootConfig_;
 
     // 内部実装
-    Response serveInternal(const Request& req) const;
+    // Response serveInternal(const Request& req) const;
     bool isCgiTarget(const Request& req,
                      std::string* scriptPath,
                      std::string* pathInfo) const;
@@ -22,12 +29,13 @@ class CgiHandler : public IHandler {
                      const std::string& scriptName,
                      const std::string* pathInfo,
                      std::vector<std::string>* env) const;
-    bool executeCgi(const std::vector<std::string>& argv,
-                    const std::vector<std::string>& env,
-                    const std::vector<char>& stdinBody,
-                    std::string* stdoutBuf,
-                    int* exitCode) const;
-    Response parseCgiAndBuildResponse(const std::string& cgiOut) const;
+    bool spawnCgiProcess(const std::vector<std::string>& argv,
+                         const std::vector<std::string>& env,
+                         CgiSpawn* out) const;
+    IAction* createCgiTask(const std::vector<std::string>& argv,
+                           const std::vector<std::string>& env,
+                           const std::vector<char>& stdinBody) const;
+
 };
 
 } // namespace http

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(webserv_lib STATIC
     server/socket/socketAddr.cpp
     server/connection/connection.cpp
     server/connection/connectionManager.cpp
+    http/actions/cgiTask.cpp
     http/request/read/body.cpp
     http/request/read/header_parsing_utils.cpp
     http/request/read/length_body.cpp
@@ -85,6 +86,7 @@ target_include_directories(webserv_lib PUBLIC
     ${PROJECT_SOURCE_DIR}/include/http/handler
     ${PROJECT_SOURCE_DIR}/include/http/handler/router
     ${PROJECT_SOURCE_DIR}/include/http/request
+    ${PROJECT_SOURCE_DIR}/include/http/actions
     ${PROJECT_SOURCE_DIR}/include/action
     ${PROJECT_SOURCE_DIR}/include/http/response
     ${PROJECT_SOURCE_DIR}/include/http/handler/router/middleware

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,11 +1,24 @@
 #include "config/config.hpp"
 
 #include <cstddef>
+#include <string>
 
 #include "data.hpp"
 #include "documentRootConfig.hpp"
 #include "locationContext.hpp"
 #include "serverContext.hpp"
+
+namespace {
+static std::string normalizeHostKey(const std::string& host) {
+    if (host.empty()) {
+        return "127.0.0.1";
+    }
+    if (host == "localhost") {
+        return "127.0.0.1";
+    }
+    return host;
+}
+} // namespace
 
 struct ConfigServerValueErrorEraser {
    private:
@@ -23,25 +36,27 @@ struct ConfigServerValueErrorEraser {
 
 struct ConfigServerDuplicateErrorEraser {
    private:
-    std::vector<int>* seenListenValue;
+    std::vector<std::pair<std::string, int> >* seenHostPlusListen;
 
    public:
-    explicit ConfigServerDuplicateErrorEraser(std::vector<int>* seen)
-        : seenListenValue(seen) {}
+    explicit ConfigServerDuplicateErrorEraser(
+        std::vector<std::pair<std::string, int> >* seen)
+        : seenHostPlusListen(seen) {}
 
     bool operator()(const ServerContext& server) {
         const int listen = server.getListen();
+        const std::string hostKey = normalizeHostKey(server.getHost());
 
-        for (std::vector<int>::iterator it = seenListenValue->begin();
-             it != seenListenValue->end(); ++it) {
-            if (*it == listen) {
+        for (std::vector<std::pair<std::string, int> >::iterator it = seenHostPlusListen->begin();
+             it != seenHostPlusListen->end(); ++it) {
+            if (it->second == listen && it->first == hostKey) {
                 std::cerr << "[ server removed: listen port "
                              "duplicate error ]"
                           << std::endl;
                 return (true);
             }
         }
-        seenListenValue->push_back(listen);
+        seenHostPlusListen->push_back(std::make_pair(hostKey, listen));
         return (false);
     }
 };
@@ -106,7 +121,7 @@ bool Config::checkAndEraseLocationNode(const ServerContext& server) {
 }
 
 void Config::removeDuplicateListenServers(std::vector<ServerContext>& servers) {
-    std::vector<int> seenListenValue;
+    std::vector<std::pair<std::string, int> > seenListenValue;
 
     servers.erase(
         std::remove_if(servers.begin(), servers.end(),

--- a/src/config/context/documentRootConfig.cpp
+++ b/src/config/context/documentRootConfig.cpp
@@ -23,7 +23,7 @@ void DocumentRootConfig::setCgiExtensions(OnOff cgiExtensions) {
     cgiExtensions_ = cgiExtensions;
 }
 
-void DocumentRootConfig::setEnabelUpload(OnOff enableUpload) {
+void DocumentRootConfig::setEnableUpload(OnOff enableUpload) {
     enableUpload_ = enableUpload;
 }
 

--- a/src/config/context/documentRootConfig.cpp
+++ b/src/config/context/documentRootConfig.cpp
@@ -1,7 +1,7 @@
 #include "documentRootConfig.hpp"
 
 DocumentRootConfig::DocumentRootConfig()
-    : index_("index.html"), autoIndex_(OFF), cgiExtensions_(OFF) {
+    : index_("index.html"), autoIndex_(OFF), cgiExtensions_(OFF), enableUpload_(OFF) {
 }
 
 DocumentRootConfig::~DocumentRootConfig() {
@@ -23,6 +23,10 @@ void DocumentRootConfig::setCgiExtensions(OnOff cgiExtensions) {
     cgiExtensions_ = cgiExtensions;
 }
 
+void DocumentRootConfig::setEnabelUpload(OnOff enableUpload) {
+    enableUpload_ = enableUpload;
+}
+
 const std::string& DocumentRootConfig::getRoot() const {
     return root_;
 }
@@ -37,6 +41,10 @@ OnOff DocumentRootConfig::getAutoIndex() const {
 
 OnOff DocumentRootConfig::getCgiExtensions() const {
     return cgiExtensions_;
+}
+
+OnOff DocumentRootConfig::getEnableUpload() const {
+    return enableUpload_;
 }
 
 bool DocumentRootConfig::isAutoindexEnabled() const {

--- a/src/config/context/serverContext.cpp
+++ b/src/config/context/serverContext.cpp
@@ -1,7 +1,7 @@
 #include "serverContext.hpp"
 
 ServerContext::ServerContext(const std::string& text)
-    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE) {
+    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("127.0.0.1") {
     // std::map<http::HttpStatusCode, std::string> errPage;
     // errPage.insert(std::make_pair(http::kStatusNotFound, "404.html"));
     // this->errorPage_.push_back(errPage);

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -22,7 +22,8 @@ void (ConfigParser::* ConfigParser::funcLocation_[FUNC_LOCATION_SIZE])(
     LocationContext&, size_t&) = {
     &ConfigParser::setRoot_,  &ConfigParser::setMethod_,
     &ConfigParser::setIndex_, &ConfigParser::setAutoIndex_,
-    &ConfigParser::setIsCgi_, &ConfigParser::setRedirect_};
+    &ConfigParser::setIsCgi_, &ConfigParser::setRedirect_,
+    &ConfigParser::setEnableUpload_};
 
 ConfigParser::ConfigParser(ConfigTokenizer& tokenizer, const std::string& confFile)
     : tokens_(tokenizer.getTokens()), depth_(0), confFile_(confFile) {
@@ -47,7 +48,7 @@ void ConfigParser::makeVectorServer_() {
                          tokens_[i].getLineNumber());
             }
             addServer_(i);
-        } else if ((type >= LISTEN && type <= REDIRECT) && this->depth_ == 0) {
+        } else if ((type >= LISTEN && type <= ENABLE_UPLOAD) && this->depth_ == 0) {
             throwErr(this->tokens_[i].getText(), ": Syntax error: line",
                      tokens_[i].getLineNumber());
         } else {
@@ -178,7 +179,7 @@ void ConfigParser::addLocation_(ServerContext& server, size_t& index) {
                 server.getLocation().push_back(location);
                 break;
             }
-        } else if (type >= ROOT && type <= REDIRECT) {
+        } else if (type >= ROOT && type <= ENABLE_UPLOAD) {
             (this->*funcLocation_[type - FUNC_SERVER_SIZE])(location, index);
         } else {
             continue;
@@ -295,6 +296,22 @@ void ConfigParser::setRedirect_(LocationContext& location, size_t& index) {
         throwErr(this->tokens_[index].getText(),
                  ": Redirect value error: line ",
                  this->tokens_[index].getLineNumber());
+    }
+}
+
+void ConfigParser::setEnableUpload_(LocationContext& location, size_t& index) {
+    const std::string select = incrementAndCheckSize_(index);
+    DocumentRootConfig& documentRootConfig = location.getDocumentRootConfig();
+
+    if (this->tokens_[index].getType() == VALUE) {
+        if (select == "ON") {
+            documentRootConfig.setEnabelUpload(ON);
+        } else if (select == "OFF") {
+            documentRootConfig.setEnabelUpload(OFF);
+        } else {
+            throwErr(select, ": Unknown select error: line ",
+                     this->tokens_[index].getLineNumber());
+        }
     }
 }
 

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -302,9 +302,9 @@ void ConfigParser::setEnableUpload_(LocationContext& location, size_t& index) {
 
     if (this->tokens_[index].getType() == VALUE) {
         if (select == "ON") {
-            documentRootConfig.setEnabelUpload(ON);
+            documentRootConfig.setEnableUpload(ON);
         } else if (select == "OFF") {
-            documentRootConfig.setEnabelUpload(OFF);
+            documentRootConfig.setEnableUpload(OFF);
         } else {
             throwErr(select, ": Unknown select error: line ",
                      this->tokens_[index].getLineNumber());

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -114,9 +114,6 @@ void ConfigParser::setHost_(ServerContext& server, size_t& index) {
 
     if (this->tokens_[index].getType() == VALUE) {
         server.setHost(hostName);
-    } else {
-        throwErr(hostName, ": Host value error: line",
-                 this->tokens_[index].getLineNumber());
     }
 }
 

--- a/src/config/testPrint.cpp
+++ b/src/config/testPrint.cpp
@@ -51,6 +51,8 @@ void Config::printLocation(const ServerContext& server) {
                   << std::endl;
         std::cout << "     |- is_cgi: " << documentRootConfig.getCgiExtensions()
                   << std::endl;
+        std::cout << "     |- enabel_upload: " << documentRootConfig.getEnableUpload()
+                  << std::endl;
         if (!location[k].getRedirect().empty()) {
             std::cout << "     |- redirect: " << location[k].getRedirect()
                       << std::endl;

--- a/src/config/token.cpp
+++ b/src/config/token.cpp
@@ -38,7 +38,7 @@ void Token::setType_(const std::string& text) {
         tokenMap.insert(std::make_pair("root", ROOT));
         tokenMap.insert(std::make_pair("server", SERVER));
         tokenMap.insert(std::make_pair("location", LOCATION));
-        tokenMap.insert(std::make_pair("location_back", LOCATION));
+        // tokenMap.insert(std::make_pair("location_back", LOCATION));
         tokenMap.insert(std::make_pair("error_page", ERR_PAGE));
         tokenMap.insert(std::make_pair("listen", LISTEN));
         tokenMap.insert(std::make_pair("host", HOST));
@@ -49,6 +49,7 @@ void Token::setType_(const std::string& text) {
         tokenMap.insert(std::make_pair("autoindex", AUTOINDEX));
         tokenMap.insert(std::make_pair("is_cgi", IS_CGI));
         tokenMap.insert(std::make_pair("redirect", REDIRECT));
+        tokenMap.insert(std::make_pair("enable_upload", ENABLE_UPLOAD));
     }
     const std::map<std::string, TokenType>::const_iterator it =
         tokenMap.find(text);
@@ -58,7 +59,7 @@ void Token::setType_(const std::string& text) {
         this->type_ = it->second;
     } else if (this->position_ == BEGINNING) {
         throw(std::runtime_error(
-            text + ": Syntax error : line " +
+            text + ": Syntax error6 : line " +
             ConfigTokenizer::numberToStr(this->lineNumber_)));
     } else {
         this->type_ = VALUE;

--- a/src/config/token.cpp
+++ b/src/config/token.cpp
@@ -59,7 +59,7 @@ void Token::setType_(const std::string& text) {
         this->type_ = it->second;
     } else if (this->position_ == BEGINNING) {
         throw(std::runtime_error(
-            text + ": Syntax error6 : line " +
+            text + ": Syntax error : line " +
             ConfigTokenizer::numberToStr(this->lineNumber_)));
     } else {
         this->type_ = VALUE;

--- a/src/http/actions/cgiTask.cpp
+++ b/src/http/actions/cgiTask.cpp
@@ -1,0 +1,162 @@
+#include "http/actions/cgiTask.hpp"
+
+#include "http/handler/file/cgi.hpp"
+#include "http/response/response.hpp"
+#include "http/response/builder.hpp"
+
+#include "cgiTask.hpp"
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/epoll.h>
+
+namespace http {
+
+const std::size_t kBufSize = 4096;
+const int STATUS128 = 128;
+
+CgiTask::CgiTask(pid_t pid, int rfd, int wfd,
+            const std::vector<char>& stdinBody,
+            const CgiHandler* owner)
+    : pid_(pid), rfd_(rfd), wfd_(wfd),
+      wPtr_(stdinBody.empty() ? NULL : &stdinBody[0]),
+      wRemain_(static_cast<ssize_t>(stdinBody.size())),
+      rClosed_(false), wClosed_(stdinBody.empty()),
+      registered_(false), reaped_(false),
+      exitCode_(0), owner_(owner) {}
+
+CgiTask::~CgiTask() {
+    closeFd(rfd_);
+    closeFd(wfd_);
+}
+
+void CgiTask::execute(ActionContext& ctx) {
+    // 初回のみepoll登録
+    registerIfNeeded(ctx);
+    // TODO
+    // const int fd = ctx.fd(); // 今回readyになったFD
+    // const unsigned int event = ctx.events();
+    // if (fd >= 0) {
+    //     handleEvent(fd, event, ctx); // read/writeを1ステップ進める
+    // }
+    // 子プロセスの死活を拾う（非ブロッキング）
+    reapChild();
+    // 条件が揃えば完了→HTTPへ
+    finishIfDone(ctx);
+}
+
+void CgiTask::registerIfNeeded(ActionContext& ctx) {
+    if (registered_) {
+        return;
+    }
+    if (rfd_ >= 0) {
+        // TODO
+        // ctx.add(rfd_, EPOLLIN, this);
+    }
+    if (wfd_ >= 0 && !wClosed_) {
+        // TODO
+        // ctx.add(wfd_, EPOLLOUT, this);
+    }
+    if (wClosed_) {
+        closeFd(wfd_);
+    }
+    registered_ = true;
+}
+
+void CgiTask::handleEvent(int fd, unsigned int event, ActionContext& ctx) {
+    if (fd == rfd_ && (event & EPOLLIN)) {
+        readOnce();
+    }
+    if (fd == wfd_ && (event & EPOLLOUT)) {
+        writeOnce(ctx);
+    }
+    // エラー/ハングアップはclose
+    if (event & (EPOLLERR | EPOLLHUP)) {
+        closeFd(fd);
+    }
+}
+
+void CgiTask::readOnce() {
+    char buf[kBufSize];
+    ssize_t readSize = ::read(rfd_, buf, sizeof(buf));
+
+    if (readSize > 0) {
+        cgiOut_.append(buf, static_cast<size_t>(readSize));
+        return;
+    }
+    if (readSize == 0) {
+        closeFd(rfd_);
+        rClosed_ = true;
+    }
+    // readSize < 0 は何もしない（errno を見て分岐しない）
+}
+
+void CgiTask::writeOnce(ActionContext& ctx) {
+    if (wRemain_ <= 0) {
+        closeFd(wfd_);
+        wClosed_ = true;
+        return;
+    }
+    ssize_t writeSize = ::write(wfd_, wPtr_, static_cast<size_t>(wRemain_));
+
+    if (writeSize > 0) {
+        wPtr_ += writeSize;
+        wRemain_ -= writeSize;
+        if (wRemain_ <= 0) {
+            closeFd(wfd_);
+            wClosed_ = true;
+            // エッジトリガで「書き切るまで」回したいなら、ここで ctx.mod(wfd_, EPOLLOUT, this) 等
+        }
+    }
+    // writeSize <= 0 は何もしない（errno を見ない）
+}
+
+void CgiTask::closeFd(int fd) {
+    if (fd == rfd_) {
+        if (rfd_ >= 0) {
+            close(rfd_);
+            rfd_ = -1;
+        }
+        rClosed_ = true;
+    }
+    if (fd == wfd_) {
+        if (wfd_ >= 0) {
+            close(wfd_);
+            wfd_ = -1;
+        }
+        wClosed_ = true;
+    }
+}
+
+void CgiTask::reapChild() {
+    if (reaped_) {
+        return;
+    }
+    int status = 0;
+    pid_t got = waitpid(pid_, &status, WNOHANG);
+    if (got == pid_) {
+        reaped_ = true;
+        if (WIFEXITED(status)) {
+            exitCode_ = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            exitCode_ = STATUS128 + WTERMSIG(status);
+        } else {
+            exitCode_ = -1;
+        }
+    }
+}
+
+void CgiTask::finishIfDone(ActionContext& ctx) {
+    if (!rClosed_ || !wClosed_ || !reaped_) {
+        // CGI 生出力 → HTTP へ
+        return;
+    }
+    // epoll から外す（存在すれば）
+    // TODO
+    // ctx.del(rfd_);
+    // ctx.del(wfd_);
+    Response resp = owner_->parseCgiAndBuildResponse(cgiOut_);
+    // TODO
+    // ctx.complete(resp);
+}
+
+}

--- a/src/http/handler/file/cgi.cpp
+++ b/src/http/handler/file/cgi.cpp
@@ -21,8 +21,8 @@ Response CgiHandler::serveInternal(const Request& req) const {
         return ResponseBuilder().status(kStatusNotFound).build();
     }
 
-    std::string joined = utils::joinPath(docRootConfig_.getRoot(), scriptPath);
-    std::string realScriptPath = utils::normalizePath(joined);
+    const std::string joined = utils::joinPath(docRootConfig_.getRoot(), scriptPath);
+    const std::string realScriptPath = utils::normalizePath(joined);
 
     std::vector<std::string> env;
     buildCgiEnv(req, scriptPath, &pathInfo, &env);

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -4,43 +4,27 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <sys/epoll.h>
+// #include <sys/epoll.h>
 
 #include <string>
 #include <vector>
 
 #include "cgi.hpp"
+#include "action.hpp"
+#include "cgiTask.hpp"
 
 namespace http {
 
 namespace {
 
-const int kStepMs = 50; // 1回の poll 待ち
-const int kTotalMs = 30000; // 総タイムアウト 30s
 const int EXIT_EXEC_FAILED = 127;
-const int STATUS128 = 128;
-const std::size_t kBufSize = 4096;
-const std::size_t kReserve = 8192;
-
-struct CgiIoCtx {
-    int epfd;
-    pid_t pid;
-    int wfd;
-    int rfd;
-    const char* wPtr;
-    ssize_t wRemain;
-    bool wClosed;
-    bool rClosed;
-    int elapsed;
-    int exitCode;
-    std::string* out;
-};
 
 // Low-level FD / pipe utils
 bool openPipes(int inPipe[2], int outPipe[2]);
 void closePipe(int pipe[2]);
 void safeClose(int* fd);
 bool setCloexec(int fd);
+bool setNonblock(int fd);
 
 // child process
 void execChildAndExit(const std::vector<std::string>& argv,
@@ -48,38 +32,14 @@ void execChildAndExit(const std::vector<std::string>& argv,
                       int inPipe[2], int outPipe[2]);
 void buildVecPtr(const std::vector<std::string>& value,
                  std::vector<char*>* out);
-        
-// parent process
-bool parentProcess(pid_t pid, int wfd, int rfd,
-                   const std::vector<char>& stdinBody,
-                   std::string* out, int* exitCode);
-            
-// utils for parent process
-bool initCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
-    const std::vector<char>& body, std::string* out);
-bool setNonblock(int fd);
-bool registerEpoll(CgiIoCtx* ctx);
-// epoll を使った CGI の入出力を最後まで回し切るメインループ
-bool ioLoop(CgiIoCtx* ctx);
-// epoll_wait → 単発の read/write → 子の生存確認 を1回だけ
-bool stepOnce(CgiIoCtx* ctx);
-// helper for ioLoop
-void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events);
-void handleRead(CgiIoCtx* ctx);
-void handleWrite(CgiIoCtx* ctx);
-void closeAndSet(CgiIoCtx* ctx, int fd);
-// helper for stepOnce
-void checkChild(CgiIoCtx* ctx);
-
 
 }  // namespace
 
 // 本体
-bool CgiHandler::executeCgi(const std::vector<std::string>& argv,
-                            const std::vector<std::string>& env,
-                            const std::vector<char>& stdinBody,
-                            std::string* stdoutBuf, int* exitCode) const {
-    if (argv.empty() || stdoutBuf == NULL || exitCode == NULL) {
+bool CgiHandler::spawnCgiProcess(const std::vector<std::string>& argv,
+                                 const std::vector<std::string>& env,
+                                 CgiSpawn* out) const {
+    if (!out) {
         return false;
     }
     int inPipe[2] = {-1, -1};
@@ -98,14 +58,24 @@ bool CgiHandler::executeCgi(const std::vector<std::string>& argv,
     }
     close(inPipe[0]);
     close(outPipe[1]);
-    const bool ok = parentProcess(pid, inPipe[1], outPipe[0], stdinBody, stdoutBuf,
-                            exitCode);
-    int status = 0;
-    if (!ok) {
-        kill(pid, SIGKILL);
-        (void)waitpid(pid, &status, 0);
+    (void)setNonblock(inPipe[1]);
+    (void)setNonblock(outPipe[0]);
+
+    out->pid = pid;
+    out->wfd = inPipe[1];
+    out->rfd = outPipe[0];
+    return true;
+}
+
+IAction* CgiHandler::createCgiTask(const std::vector<std::string>& argv,
+                                   const std::vector<std::string>& env,
+                                   const std::vector<char>& stdinBody) const {
+    CgiSpawn spawn;
+
+    if (!spawnCgiProcess(argv, env, &spawn)) {
+        return NULL;
     }
-    return ok;
+    return new CgiTask(spawn.pid, spawn.rfd, spawn.wfd, stdinBody, this);
 }
 
 namespace {
@@ -155,6 +125,17 @@ bool setCloexec(int fd) {
     return fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
 }
 
+bool setNonblock(int fd) {
+    if (fd < 0) {
+        return false;
+    }
+    const int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) {
+        return false;
+    }
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
 // child process
 void execChildAndExit(const std::vector<std::string>& argv,
                       const std::vector<std::string>& env, int inPipe[2],
@@ -192,240 +173,5 @@ void buildVecPtr(const std::vector<std::string>& value,
     out->push_back(0);
 }
 
-// parent process
-bool parentProcess(pid_t pid, int wfd, int rfd, const std::vector<char>& body,
-                   std::string* out, int* exitCode) {
-    if (out == NULL || exitCode == NULL) {
-        return false;
-    }
-    CgiIoCtx ctx;
-    if (!initCtx(&ctx, pid, wfd, rfd, body, out)) {
-        safeClose(&wfd);
-        safeClose(&rfd);
-        int status = 0;
-        (void)waitpid(pid, &status, 0);
-        return false;
-    }
-    bool ok = ioLoop(&ctx);
-    *exitCode = ctx.exitCode;
-    safeClose(&ctx.epfd);
-    return ok;
-}
-
-// utils for parent process
-bool initCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
-            const std::vector<char>& body, std::string* out) {
-    ctx->epfd = epoll_create1(EPOLL_CLOEXEC);
-    if (ctx->epfd < 0) {
-        return false;
-    }
-    ctx->pid = pid;
-    ctx->wfd = wfd;
-    ctx->rfd = rfd;
-    ctx->wPtr = body.empty() ? NULL : &body[0];
-    ctx->wRemain = static_cast<ssize_t>(body.size());
-    ctx->wClosed = (ctx->wRemain == 0);
-    ctx->rClosed = false;
-    ctx->elapsed = 0;
-    ctx->exitCode = 0;
-    ctx->out = out;
-    out->clear();
-    out->reserve(kReserve);
-    (void)setNonblock(ctx->rfd);
-    (void)setNonblock(ctx->wfd);
-    if (!registerEpoll(ctx)) {
-        safeClose(&ctx->epfd);
-        return false;
-    }
-    return true;
-}
-
-// helper for initCtx
-bool setNonblock(int fd) {
-    if (fd < 0) {
-        return false;
-    }
-    const int flags = fcntl(fd, F_GETFL, 0);
-    if (flags < 0) {
-        return false;
-    }
-    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
-}
-
-// helper for initCtx
-bool registerEpoll(CgiIoCtx* ctx) {
-    bool wOk = true;
-    bool rOk = true;
-    struct epoll_event event;
-
-    // epollに監視を登録「書けるようになったら通知して」
-    if (!ctx->wClosed && ctx->wfd >= 0) {
-        memset(&event, 0, sizeof(event));
-        event.events = EPOLLOUT;
-        event.data.fd = ctx->wfd;
-        wOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->wfd, &event) == 0); 
-    }
-    // epollに監視を登録「読めるようになったら通知して」
-    if (!ctx->rClosed && ctx->rfd >= 0) {
-        memset(&event, 0, sizeof(event));
-        event.events = EPOLLIN;
-        event.data.fd = ctx->rfd;
-        rOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->rfd, &event) == 0); 
-    }
-    if (ctx->wClosed) {
-        safeClose(&ctx->wfd);
-    }
-    return wOk && rOk;
-}
-
-// epoll 駆動で CGI 子プロセスとの I/O を完了/失敗まで進めるメインループ。
-//   - stepOnce() を繰り返し呼び、rfd を読み切り & wfd を書き切るまで継続
-//   - 途中で stepOnce() が false を返したらタイムアウト/異常として false を返す
-//   - 正常終了時は waitpid() で子を回収し、ctx->exitCode を確定
-// Returns:
-//   true  = 正常終了（I/O 完了→wait まで完了）
-//   false = タイムアウト等で中断（kill は呼び出し側で実施）
-// Side effects:
-//   ctx->out に出力を蓄積, ctx->rClosed/wClosed/exitCode を更新
-bool ioLoop(CgiIoCtx* ctx) {
-    while (!ctx->rClosed || !ctx->wClosed) {
-        // epoll 駆動の “I/Oポンプ” の1回分
-        if (!stepOnce(ctx)) {
-            return false;
-        }
-    }
-    int status = 0;
-    (void)waitpid(ctx->pid, &status, 0);
-    if (ctx->exitCode == 0) {
-        if (WIFEXITED(status)) {
-            ctx->exitCode = WEXITSTATUS(status);
-            return true;
-        }
-        if (WIFSIGNALED(status)) {
-            ctx->exitCode = STATUS128 + WTERMSIG(status);
-            return true;
-        }
-        ctx->exitCode = -1;
-    }
-    return true;
-}
-
-// CGI 子プロセスとのノンブロッキング入出力を “1ステップ” だけ進めるための関数
-bool stepOnce(CgiIoCtx* ctx) {
-    // rfd と wfd の“準備完了イベント”を受け取るためのバッファ
-    epoll_event evs[2];
-    const int readyEvents = epoll_wait(ctx->epfd, evs, 2, kStepMs);
-
-    if (readyEvents < 0) {
-        return true;
-    }
-    if (readyEvents == 0) {
-        ctx->elapsed += kStepMs;
-        // アイドル（無イベント）状態の総時間で CGI をタイムアウトさせる
-        if (ctx->elapsed >= kTotalMs) {
-            safeClose(&ctx->rfd);
-            safeClose(&ctx->wfd);
-            return false;
-        }
-        return true; // イベントなしはここで1ステップ終了
-    }
-    ctx->elapsed = 0; // イベントが来たらリセット
-    for (int i = 0; i < readyEvents; ++i) {
-        // イベントが起きたFD
-        const int fd = evs[i].data.fd;
-        // 何の種類のイベントが起きたかのビットマスク
-        const unsigned int events = evs[i].events; 
-        proceedEvent(ctx, fd, events);
-    }
-    checkChild(ctx);
-    return true;
-}
-
-// helper function for stepOnce
-void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events) {
-    if (fd == ctx->rfd && (events & EPOLLIN)) { // 読み
-        handleRead(ctx);
-    }
-    if (fd == ctx->wfd && (events & EPOLLOUT)) { // 書き
-        handleWrite(ctx);
-    }
-    // rfd: EPOLLINが無いときだけHUP/ERRで閉じる（読み残し保護）
-    if (fd == ctx->rfd && !(events & EPOLLIN) && 
-        (events & (EPOLLERR | EPOLLHUP))) {
-        closeAndSet(ctx, fd);
-    }
-    // wfd: HUP/ERRなら即クローズ
-    if (fd == ctx->wfd && (events & (EPOLLHUP | EPOLLERR))) {
-        closeAndSet(ctx, fd);
-    }
-}
-
-// 読む
-void handleRead(CgiIoCtx* ctx) {
-    char buf[kBufSize];
-    const ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
-    if (byte > 0) {
-        ctx->out->append(buf, static_cast<std::size_t>(byte));
-        return;
-    }
-    if (byte == 0) { // EOF
-        safeClose(&ctx->rfd);
-        ctx->rClosed = true;
-    }
-    // n < 0 は何もしない（errno は見ない）
-}
-
-// 書く
-void handleWrite(CgiIoCtx* ctx) {
-    if (ctx->wRemain <= 0) {
-        if (!ctx->wClosed) {
-            safeClose(&ctx->wfd);
-            ctx->wClosed = true;
-        }
-        return;
-    }
-    const ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
-    if (byte > 0) {
-        ctx->wPtr += byte;
-        ctx->wRemain -= byte;
-        if (ctx->wRemain <= 0) {
-            safeClose(&ctx->wfd);
-            ctx->wClosed = true;
-        }
-    }
-    // byte <= 0 は何もしない（errno は見ない）
-}
-
-// helper for proceedEvent
-void closeAndSet(CgiIoCtx* ctx, int fd) {
-    if (fd == ctx->rfd) {
-        safeClose(&ctx->rfd);
-        ctx->rClosed = true;
-    }
-    if (fd == ctx->wfd) {
-        safeClose(&ctx->wfd);
-        ctx->wClosed = true;
-    } 
-}
-
-// helper for stepOnce
-void checkChild(CgiIoCtx* ctx) {
-    int status = 0;
-    const pid_t got = waitpid(ctx->pid, &status, WNOHANG);
-    if (got != ctx->pid) {
-        return;
-    }
-    if (WIFEXITED(status)) {
-        ctx->exitCode = WEXITSTATUS(status);
-        return;
-    }
-    if (WIFSIGNALED(status)) {
-        ctx->exitCode = STATUS128 + WTERMSIG(status);
-        return;
-    }
-    ctx->exitCode = -1;
-}
-
-}  // namespace
-
-}  // namespace http
+} // namespace
+} // namespace http

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -41,7 +41,6 @@ bool openPipes(int inPipe[2], int outPipe[2]);
 void closePipe(int pipe[2]);
 void safeClose(int* fd);
 bool setCloexec(int fd);
-// int makeNonblock(int fd);
 
 // child process
 void execChildAndExit(const std::vector<std::string>& argv,
@@ -207,7 +206,6 @@ bool parentProcess(pid_t pid, int wfd, int rfd, const std::vector<char>& body,
         (void)waitpid(pid, &status, 0);
         return false;
     }
-    // 
     bool ok = ioLoop(&ctx);
     *exitCode = ctx.exitCode;
     safeClose(&ctx.epfd);

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -247,7 +247,7 @@ bool setNonblock(int fd) {
     if (fd < 0) {
         return false;
     }
-    int flags = fcntl(fd, F_GETFL, 0);
+    const int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) {
         return false;
     }
@@ -316,7 +316,7 @@ bool ioLoop(CgiIoCtx* ctx) {
 bool stepOnce(CgiIoCtx* ctx) {
     // rfd と wfd の“準備完了イベント”を受け取るためのバッファ
     epoll_event evs[2];
-    int readyEvents = epoll_wait(ctx->epfd, evs, 2, kStepMs);
+    const int readyEvents = epoll_wait(ctx->epfd, evs, 2, kStepMs);
 
     if (readyEvents < 0) {
         return true;
@@ -334,9 +334,9 @@ bool stepOnce(CgiIoCtx* ctx) {
     ctx->elapsed = 0; // イベントが来たらリセット
     for (int i = 0; i < readyEvents; ++i) {
         // イベントが起きたFD
-        int fd = evs[i].data.fd;
+        const int fd = evs[i].data.fd;
         // 何の種類のイベントが起きたかのビットマスク
-        unsigned int events = evs[i].events; 
+        const unsigned int events = evs[i].events; 
         proceedEvent(ctx, fd, events);
     }
     checkChild(ctx);
@@ -365,7 +365,7 @@ void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events) {
 // 読む
 void handleRead(CgiIoCtx* ctx) {
     char buf[kBufSize];
-    ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
+    const ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
     if (byte > 0) {
         ctx->out->append(buf, static_cast<std::size_t>(byte));
         return;
@@ -386,7 +386,7 @@ void handleWrite(CgiIoCtx* ctx) {
         }
         return;
     }
-    ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
+    const ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
     if (byte > 0) {
         ctx->wPtr += byte;
         ctx->wRemain -= byte;
@@ -413,7 +413,7 @@ void closeAndSet(CgiIoCtx* ctx, int fd) {
 // helper for stepOnce
 void checkChild(CgiIoCtx* ctx) {
     int status = 0;
-    pid_t got = waitpid(ctx->pid, &status, WNOHANG);
+    const pid_t got = waitpid(ctx->pid, &status, WNOHANG);
     if (got != ctx->pid) {
         return;
     }

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -133,7 +133,7 @@ bool setNonblock(int fd) {
         return false;
     }
     const int flags = fcntl(fd, F_GETFL, 0);
-    if (flags == -1) {
+    if (flags < 0) {
         return false;
     }
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -4,7 +4,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <signal.h>
 #include <sys/epoll.h>
 
 #include <string>
@@ -37,132 +36,41 @@ struct CgiIoCtx {
     std::string* out;
 };
 
-void safeClose(int* fd) {
-    if (fd && *fd >= 0) {
-        close(*fd);
-        *fd = -1;
-    }
-}
-
-int makeNonblock(int fd) {
-    int fdFlags = fcntl(fd, F_GETFL, 0);
-    if (fdFlags < 0) {
-        return -1;
-    }
-    return fcntl(fd, F_SETFL, fdFlags | O_NONBLOCK);
-}
-
-bool epAdd(int epfd, int fd, u_int32_t evs) {
-    epoll_event event;
-    event.events = evs;
-    event.data.fd = fd;
-    return epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event) == 0;
-}
-
-void iniCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
-            const std::vector<char>& body, std::string* out) {
-    ctx->epfd = epoll_create1(0);
-    ctx->pid = pid;
-    ctx->wfd = wfd;
-    ctx->rfd = rfd;
-    ctx->wPtr = body.empty() ? NULL : &body[0];
-    ctx->wRemain = static_cast<ssize_t>(body.size());
-    ctx->wClosed = (ctx->wRemain == 0);
-    ctx->rClosed = false;
-    ctx->elapsed = 0;
-    ctx->exitCode = 0;
-    ctx->out = out;
-    out->clear();
-    out->reserve(kReserve);
-    if (ctx->rfd >= 0) { // nonblockingをセット
-        makeNonblock(ctx->rfd);
-    }
-    if (ctx->wfd >= 0) { // nonblockingをセット
-        makeNonblock(ctx->wfd);
-    }
-    if (!ctx->wClosed && ctx->wfd >= 0) { // epollに監視を登録「書けるようになったら通知して」
-        epAdd(ctx->epfd, ctx->wfd, EPOLLOUT);
-    }
-    if (!ctx->rClosed && ctx->rfd >= 0) { // epollに監視を登録「読めるようになったら通知して」
-        epAdd(ctx->epfd, ctx->rfd, EPOLLIN);
-    }
-    if (ctx->wClosed) {
-        safeClose(&wfd);
-    }
-}
-
-void handleRead(CgiIoCtx* ctx) {
-    char buf[kBufSize];
-    for(;;) {
-        ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
-        if (byte > 0) {
-            ctx->out->append(buf, static_cast<std::size_t>(byte));
-            continue;
-        }
-        if (byte == 0) {
-            safeClose(&ctx->rfd);
-            ctx->rClosed = true;
-            break;
-        }
-    }
-}
-
-void handleWrite(CgiIoCtx* ctx) {
-    while (ctx->wRemain > 0) {
-        ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
-        if (byte > 0) {
-            ctx->wPtr += byte;
-            ctx->wRemain -= byte;
-            continue;
-        }
-        break;
-    }
-    if (ctx->wRemain <= 0) {
-        safeClose(&ctx->wfd);
-        ctx->wClosed = true;
-    }
-}
-
-void checkChild(CgiIoCtx* ctx) {
-    int status = 0;
-    pid_t got = waitpid(ctx->pid, &status, WNOHANG);
-    if (got != ctx->pid) {
-        return;
-    }
-    if (WIFEXITED(status)) {
-        ctx->exitCode = WEXITSTATUS(status);
-        return;
-    }
-    if (WIFSIGNALED(status)) {
-        ctx->exitCode = STATUS128 + WTERMSIG(status);
-        return;
-    }
-    ctx->exitCode = -1;
-}
-
-
-
-
-// utils for executeCgi()
+// Low-level FD / pipe utils
 bool openPipes(int inPipe[2], int outPipe[2]);
-bool setCloexec(int fd);
 void closePipe(int pipe[2]);
+void safeClose(int* fd);
+bool setCloexec(int fd);
+// int makeNonblock(int fd);
 
 // child process
 void execChildAndExit(const std::vector<std::string>& argv,
-                      const std::vector<std::string>& env, int inPipe[2],
-                      int outPipe[2]);
-// utils fo execChildAndExit()
+                      const std::vector<std::string>& env, 
+                      int inPipe[2], int outPipe[2]);
 void buildVecPtr(const std::vector<std::string>& value,
-    std::vector<char*>* out);
-
+                 std::vector<char*>* out);
+        
 // parent process
 bool parentProcess(pid_t pid, int wfd, int rfd,
-                   const std::vector<char>& stdinBody, std::string* out,
-                   int* exitCode);
+                   const std::vector<char>& stdinBody,
+                   std::string* out, int* exitCode);
+            
 // utils for parent process
-bool doWrite(pid_t pid, int wfd, int rfd, const char* ptr, ssize_t remain);
-bool doRead(pid_t pid, int rfd, std::string* out);
+bool initCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
+    const std::vector<char>& body, std::string* out);
+bool setNonblock(int fd);
+bool registerEpoll(CgiIoCtx* ctx);
+// epoll を使った CGI の入出力を最後まで回し切るメインループ
+bool ioLoop(CgiIoCtx* ctx);
+// epoll_wait → 単発の read/write → 子の生存確認 を1回だけ
+bool stepOnce(CgiIoCtx* ctx);
+// helper for ioLoop
+void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events);
+void handleRead(CgiIoCtx* ctx);
+void handleWrite(CgiIoCtx* ctx);
+void closeAndSet(CgiIoCtx* ctx, int fd);
+// helper for stepOnce
+void checkChild(CgiIoCtx* ctx);
 
 
 }  // namespace
@@ -221,15 +129,6 @@ bool openPipes(int inPipe[2], int outPipe[2]) {
     return true;
 }
 
-bool setCloexec(int fd) {
-    const int flags = fcntl(fd, F_GETFD);
-    if (flags < 0) {
-        return false;
-    }
-    // exec したときにこのFDを自動で閉じる
-    return fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
-}
-
 void closePipe(int pipe[2]) {
     if (pipe[0] >= 0) {
         close(pipe[0]);
@@ -239,6 +138,22 @@ void closePipe(int pipe[2]) {
         close(pipe[1]);
         pipe[1] = -1;
     }
+}
+
+void safeClose(int* fd) {
+    if (fd && *fd >= 0) {
+        close(*fd);
+        *fd = -1;
+    }
+}
+
+bool setCloexec(int fd) {
+    const int flags = fcntl(fd, F_GETFD);
+    if (flags < 0) {
+        return false;
+    }
+    // exec したときにこのFDを自動で閉じる
+    return fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
 }
 
 // child process
@@ -281,70 +196,236 @@ void buildVecPtr(const std::vector<std::string>& value,
 // parent process
 bool parentProcess(pid_t pid, int wfd, int rfd, const std::vector<char>& body,
                    std::string* out, int* exitCode) {
-    if (out == NULL || exitCode == NULL) return false;
-    out->clear();
-    int elapsed = 0;
-    const char* ptr = body.empty() ? NULL : &body[0];
-    const ssize_t remain = static_cast<ssize_t>(body.size());
-
-    if (!doWrite(pid, wfd, rfd, ptr, remain)) return false;
-    if (!doRead(pid, rfd, out)) return false;
-    int status = 0;
-    if (waitpid(pid, &status, 0) < 0) {
-        // sigaction(SIGPIPE, &sa_old, NULL);
+    if (out == NULL || exitCode == NULL) {
         return false;
     }
-    if (WIFEXITED(status)) {
-        *exitCode = WEXITSTATUS(status);
-    } else if (WIFSIGNALED(status)) {
-        *exitCode = STATUS128 + WTERMSIG(status);
-    } else {
-        *exitCode = -1;
+    CgiIoCtx ctx;
+    if (!initCtx(&ctx, pid, wfd, rfd, body, out)) {
+        safeClose(&wfd);
+        safeClose(&rfd);
+        int status = 0;
+        (void)waitpid(pid, &status, 0);
+        return false;
     }
-    // sigaction(SIGPIPE, &sa_old, NULL);
-    return true;
+    // 
+    bool ok = ioLoop(&ctx);
+    *exitCode = ctx.exitCode;
+    safeClose(&ctx.epfd);
+    return ok;
 }
 
 // utils for parent process
-bool doWrite(pid_t pid, int wfd, int rfd, const char* ptr, ssize_t remain) {
-    while (remain > 0) {
-        const ssize_t byte = write(wfd, ptr, static_cast<size_t>(remain));
-        if (byte < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            close(wfd);
-            close(rfd);
-            (void)waitpid(pid, 0, 0);
-            return false;
-        }
-        remain -= byte;
-        ptr += byte;
+bool initCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
+            const std::vector<char>& body, std::string* out) {
+    ctx->epfd = epoll_create1(EPOLL_CLOEXEC);
+    if (ctx->epfd < 0) {
+        return false;
     }
-    close(wfd);
+    ctx->pid = pid;
+    ctx->wfd = wfd;
+    ctx->rfd = rfd;
+    ctx->wPtr = body.empty() ? NULL : &body[0];
+    ctx->wRemain = static_cast<ssize_t>(body.size());
+    ctx->wClosed = (ctx->wRemain == 0);
+    ctx->rClosed = false;
+    ctx->elapsed = 0;
+    ctx->exitCode = 0;
+    ctx->out = out;
+    out->clear();
+    out->reserve(kReserve);
+    (void)setNonblock(ctx->rfd);
+    (void)setNonblock(ctx->wfd);
+    if (!registerEpoll(ctx)) {
+        safeClose(&ctx->epfd);
+        return false;
+    }
     return true;
 }
 
-bool doRead(pid_t pid, int rfd, std::string* out) {
-    out->reserve(kReserve);
-    while (true) {
-        char buf[kBufSize];
-        const ssize_t byte = read(rfd, buf, sizeof(buf));
-        if (byte < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            close(rfd);
-            (void)waitpid(pid, 0, 0);
+// helper for initCtx
+bool setNonblock(int fd) {
+    if (fd < 0) {
+        return false;
+    }
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        return false;
+    }
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+// helper for initCtx
+bool registerEpoll(CgiIoCtx* ctx) {
+    bool wOk = true;
+    bool rOk = true;
+    struct epoll_event event;
+
+    // epollに監視を登録「書けるようになったら通知して」
+    if (!ctx->wClosed && ctx->wfd >= 0) {
+        memset(&event, 0, sizeof(event));
+        event.events = EPOLLOUT;
+        event.data.fd = ctx->wfd;
+        wOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->wfd, &event) == 0); 
+    }
+    // epollに監視を登録「読めるようになったら通知して」
+    if (!ctx->rClosed && ctx->rfd >= 0) {
+        memset(&event, 0, sizeof(event));
+        event.events = EPOLLIN;
+        event.data.fd = ctx->rfd;
+        rOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->rfd, &event) == 0); 
+    }
+    if (ctx->wClosed) {
+        safeClose(&ctx->wfd);
+    }
+    return wOk && rOk;
+}
+
+// epoll 駆動で CGI 子プロセスとの I/O を完了/失敗まで進めるメインループ。
+//   - stepOnce() を繰り返し呼び、rfd を読み切り & wfd を書き切るまで継続
+//   - 途中で stepOnce() が false を返したらタイムアウト/異常として false を返す
+//   - 正常終了時は waitpid() で子を回収し、ctx->exitCode を確定
+// Returns:
+//   true  = 正常終了（I/O 完了→wait まで完了）
+//   false = タイムアウト等で中断（kill は呼び出し側で実施）
+// Side effects:
+//   ctx->out に出力を蓄積, ctx->rClosed/wClosed/exitCode を更新
+bool ioLoop(CgiIoCtx* ctx) {
+    while (!ctx->rClosed || !ctx->wClosed) {
+        // epoll 駆動の “I/Oポンプ” の1回分
+        if (!stepOnce(ctx)) {
             return false;
         }
-        if (byte == 0) {
-            break;
-        }
-        out->append(buf, static_cast<size_t>(byte));
     }
-    close(rfd);
+    int status = 0;
+    (void)waitpid(ctx->pid, &status, 0);
+    if (ctx->exitCode == 0) {
+        if (WIFEXITED(status)) {
+            ctx->exitCode = WEXITSTATUS(status);
+            return true;
+        }
+        if (WIFSIGNALED(status)) {
+            ctx->exitCode = STATUS128 + WTERMSIG(status);
+            return true;
+        }
+        ctx->exitCode = -1;
+    }
     return true;
+}
+
+// CGI 子プロセスとのノンブロッキング入出力を “1ステップ” だけ進めるための関数
+bool stepOnce(CgiIoCtx* ctx) {
+    // rfd と wfd の“準備完了イベント”を受け取るためのバッファ
+    epoll_event evs[2];
+    int readyEvents = epoll_wait(ctx->epfd, evs, 2, kStepMs);
+
+    if (readyEvents < 0) {
+        return true;
+    }
+    if (readyEvents == 0) {
+        ctx->elapsed += kStepMs;
+        // アイドル（無イベント）状態の総時間で CGI をタイムアウトさせる
+        if (ctx->elapsed >= kTotalMs) {
+            safeClose(&ctx->rfd);
+            safeClose(&ctx->wfd);
+            return false;
+        }
+        return true; // イベントなしはここで1ステップ終了
+    }
+    ctx->elapsed = 0; // イベントが来たらリセット
+    for (int i = 0; i < readyEvents; ++i) {
+        // イベントが起きたFD
+        int fd = evs[i].data.fd;
+        // 何の種類のイベントが起きたかのビットマスク
+        unsigned int events = evs[i].events; 
+        proceedEvent(ctx, fd, events);
+    }
+    checkChild(ctx);
+    return true;
+}
+
+// helper function for stepOnce
+void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events) {
+    if (fd == ctx->rfd && (events & EPOLLIN)) { // 読み
+        handleRead(ctx);
+    }
+    if (fd == ctx->wfd && (events & EPOLLOUT)) { // 書き
+        handleWrite(ctx);
+    }
+    // rfd: EPOLLINが無いときだけHUP/ERRで閉じる（読み残し保護）
+    if (fd == ctx->rfd && !(events & EPOLLIN) && 
+        (events & (EPOLLERR | EPOLLHUP))) {
+        closeAndSet(ctx, fd);
+    }
+    // wfd: HUP/ERRなら即クローズ
+    if (fd == ctx->wfd && (events & (EPOLLHUP | EPOLLERR))) {
+        closeAndSet(ctx, fd);
+    }
+}
+
+// 読む
+void handleRead(CgiIoCtx* ctx) {
+    char buf[kBufSize];
+    ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
+    if (byte > 0) {
+        ctx->out->append(buf, static_cast<std::size_t>(byte));
+        return;
+    }
+    if (byte == 0) { // EOF
+        safeClose(&ctx->rfd);
+        ctx->rClosed = true;
+    }
+    // n < 0 は何もしない（errno は見ない）
+}
+
+// 書く
+void handleWrite(CgiIoCtx* ctx) {
+    if (ctx->wRemain <= 0) {
+        if (!ctx->wClosed) {
+            safeClose(&ctx->wfd);
+            ctx->wClosed = true;
+        }
+        return;
+    }
+    ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
+    if (byte > 0) {
+        ctx->wPtr += byte;
+        ctx->wRemain -= byte;
+        if (ctx->wRemain <= 0) {
+            safeClose(&ctx->wfd);
+            ctx->wClosed = true;
+        }
+    }
+    // byte <= 0 は何もしない（errno は見ない）
+}
+
+// helper for proceedEvent
+void closeAndSet(CgiIoCtx* ctx, int fd) {
+    if (fd == ctx->rfd) {
+        safeClose(&ctx->rfd);
+        ctx->rClosed = true;
+    }
+    if (fd == ctx->wfd) {
+        safeClose(&ctx->wfd);
+        ctx->wClosed = true;
+    } 
+}
+
+// helper for stepOnce
+void checkChild(CgiIoCtx* ctx) {
+    int status = 0;
+    pid_t got = waitpid(ctx->pid, &status, WNOHANG);
+    if (got != ctx->pid) {
+        return;
+    }
+    if (WIFEXITED(status)) {
+        ctx->exitCode = WEXITSTATUS(status);
+        return;
+    }
+    if (WIFSIGNALED(status)) {
+        ctx->exitCode = STATUS128 + WTERMSIG(status);
+        return;
+    }
+    ctx->exitCode = -1;
 }
 
 }  // namespace

--- a/src/http/handler/file/upload.cpp
+++ b/src/http/handler/file/upload.cpp
@@ -25,6 +25,11 @@ Either<IAction*, Response> UploadFileHandler::serve(const Request& request) {
 }
 
 Response UploadFileHandler::serveInternal(const Request& request) const {
+    // このロケーションでアップロードが許可されていなければ拒否
+    if (!docRootConfig_.getEnableUpload()) {
+        return ResponseBuilder().status(kStatusForbidden).build();
+    }
+
     // Parser が decode + remove_dot_segments 済みのパスを返す前提
     const std::string& rel = request.getPath();
 

--- a/test/http/handler/file/CMakeLists.txt
+++ b/test/http/handler/file/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(redirect_test redirect_test.cpp)
 add_executable(static_test static_test.cpp)
 add_executable(upload_test upload_test.cpp)
 add_executable(cgi_test cgi_test.cpp)
+add_executable(cgi_epoll_test cgi_epoll_test.cpp)
 
 # 依存関係を追加
 add_dependencies(delete_test webserv_lib)
@@ -10,6 +11,7 @@ add_dependencies(redirect_test webserv_lib)
 add_dependencies(static_test webserv_lib)
 add_dependencies(upload_test webserv_lib)
 add_dependencies(cgi_test webserv_lib)
+add_dependencies(cgi_epoll_test webserv_lib)
 
 # ライブラリをリンク
 target_link_libraries(delete_test PRIVATE webserv_lib gtest_main gmock_main)
@@ -17,6 +19,7 @@ target_link_libraries(redirect_test PRIVATE webserv_lib gtest_main gmock_main)
 target_link_libraries(static_test PRIVATE webserv_lib gtest_main gmock_main)
 target_link_libraries(upload_test PRIVATE webserv_lib gtest_main gmock_main)
 target_link_libraries(cgi_test PRIVATE webserv_lib gtest_main gmock_main)
+target_link_libraries(cgi_epoll_test PRIVATE webserv_lib gtest_main gmock_main)
 
 # テストを検出
 gtest_discover_tests(delete_test)
@@ -24,3 +27,4 @@ gtest_discover_tests(redirect_test)
 gtest_discover_tests(static_test)
 gtest_discover_tests(upload_test)
 gtest_discover_tests(cgi_test)
+gtest_discover_tests(cgi_epoll_test)

--- a/test/http/handler/file/cgi_epoll_test.cpp
+++ b/test/http/handler/file/cgi_epoll_test.cpp
@@ -1,0 +1,274 @@
+// // cgi_epoll_test.cpp
+// // テスト専用：CGI の最小ケース（ヘッダ無しで "hello" を返す）
+// // - 既存の repo 配下に tmp/ があればそこを使い、無ければ /tmp に一時生成して掃除します
+// // - CgiHandler::serve(...) を利用（serveInternal は使いません）
+
+// #include <gtest/gtest.h>
+// #include <signal.h>
+// #include <fstream>
+// #include <sstream>
+// #include <string>
+// #include <vector>
+// #include <cstdio>
+// #include <cerrno>
+// #include <sys/stat.h>
+// #include <unistd.h>
+
+// #if __has_include(<filesystem>)
+//   #include <filesystem>
+//   namespace fs = std::filesystem;
+//   #define WS_HAVE_FS 1
+// #else
+//   #define WS_HAVE_FS 0
+// #endif
+
+// // ===== あなたのプロジェクトのヘッダ =====
+// #include "config/config.hpp"                         // Config
+// #include "config/context/serverContext.hpp"          // ServerContext
+// #include "config/context/locationContext.hpp"        // LocationContext
+// #include "config/context/documentRootConfig.hpp"     // DocumentRootConfig
+// #include "http/handler/file/cgi.hpp"                 // http::CgiHandler
+// #include "http/request/request.hpp"                  // http::Request
+// #include "http/response/response.hpp"                // http::Response
+// #include "http/response/builder.hpp"                 // ResponseBuilder
+// // Either / IAction / RawHeaders が別ヘッダなら追加インクルードしてください。
+// // #include "utils/either.hpp"
+// // #include "http/request/raw_headers.hpp"
+
+// namespace { // ====== 共通ユーティリティ（テストからのみ使用） ======
+
+// // レスポンス本文（Option を unwrap。None の場合は空文字）
+// static std::string GetBody(const http::Response& resp) {
+//     const types::Option<std::string>& opt = resp.getBody();
+//     return opt.isSome() ? opt.unwrap() : std::string();
+// }
+
+// // レスポンスヘッダを軽量に取得（nameLower は小文字で渡す）
+// static std::string GetHeader(const http::Response& resp, const std::string& nameLower) {
+//     std::string text = const_cast<http::Response&>(resp).toString();
+
+//     std::string::size_type headerEnd = text.find("\r\n\r\n");
+//     if (headerEnd == std::string::npos) headerEnd = text.find("\n\n");
+//     if (headerEnd == std::string::npos) return std::string();
+
+//     std::string::size_type cur = 0;
+//     while (cur < headerEnd) {
+//         std::string::size_type eol = text.find('\n', cur);
+//         if (eol == std::string::npos || eol > headerEnd) eol = headerEnd;
+
+//         std::string line = text.substr(cur, eol - cur);
+//         if (!line.empty() && line[line.size() - 1] == '\r') {
+//             line.erase(line.size() - 1);
+//         }
+
+//         std::string::size_type colon = line.find(':');
+//         if (colon != std::string::npos) {
+//             std::string key = line.substr(0, colon);
+//             std::string val = line.substr(colon + 1);
+
+//             while (!val.empty() && (val[0] == ' ' || val[0] == '\t')) {
+//                 val.erase(0, 1);
+//             }
+//             while (!val.empty() && (val[val.size() - 1] == ' ' || val[val.size() - 1] == '\t')) {
+//                 val.erase(val.size() - 1);
+//             }
+//             for (std::size_t i = 0; i < key.size(); ++i) {
+//                 char ch = key[i];
+//                 if ('A' <= ch && ch <= 'Z') key[i] = static_cast<char>(ch - 'A' + 'a');
+//             }
+//             if (key == nameLower) return val;
+//         }
+//         if (eol == headerEnd) break;
+//         cur = eol + 1;
+//     }
+//     return std::string();
+// }
+
+// struct TmpRoot {
+// #if WS_HAVE_FS
+//     fs::path path;
+// #else
+//     std::string path;
+// #endif
+//     bool owned = false;
+//     ~TmpRoot() {
+//         if (!owned) return;
+// #if WS_HAVE_FS
+//         std::error_code ec;
+//         fs::remove_all(path, ec);
+// #else
+//         // POSIX fallback:
+//         // 再帰削除は安全配慮で省略（このテストでは conf と hello.cgi のみ作成する前提）
+//         // 必要なら独自の再帰削除を実装してください。
+// #endif
+//     }
+// };
+
+// // tmp/ があればそれを使う。無ければ /tmp 下に新規作成してテスト後に掃除。
+// static TmpRoot GetTmpRoot() {
+//     TmpRoot root;
+// #if WS_HAVE_FS
+//     if (fs::exists("tmp") && fs::is_directory("tmp")) {
+//         root.path  = fs::absolute("tmp");
+//         root.owned = false; // 既存は消さない
+//     } else {
+//         fs::path created = fs::temp_directory_path() /
+//                            ("ws_cgi_test_" + std::to_string(getpid()));
+//         fs::create_directories(created);
+//         root.path  = created;
+//         root.owned = true; // 後始末する
+//     }
+// #else
+//     char buf[256];
+//     snprintf(buf, sizeof(buf), "/tmp/ws_cgi_test_%d", static_cast<int>(getpid()));
+//     mkdir(buf, 0700); // 既に存在していてもOK
+//     root.path  = buf;
+//     root.owned = true;
+// #endif
+//     return root;
+// }
+
+// static bool WriteTextFile(const std::string& filePath, const std::string& text) {
+//     std::ofstream ofs(filePath.c_str());
+//     if (!ofs.is_open()) return false;
+//     ofs << text;
+//     return true;
+// }
+
+// static bool MakeExecutable(const std::string& filePath) {
+// #if WS_HAVE_FS
+//     fs::permissions(filePath,
+//         fs::perms::owner_exec|fs::perms::owner_read|fs::perms::owner_write|
+//         fs::perms::group_exec|fs::perms::group_read|
+//         fs::perms::others_exec,
+//         fs::perm_options::add);
+//     return true;
+// #else
+//     struct stat st;
+//     if (stat(filePath.c_str(), &st) != 0) return false;
+//     mode_t mode = st.st_mode | S_IXUSR | S_IRUSR | S_IWUSR | S_IXGRP | S_IXOTH;
+//     return chmod(filePath.c_str(), mode) == 0;
+// #endif
+// }
+
+// // Either<IAction*, Response> を最終的な Response まで解決するヘルパ。
+// // 非同期アクション(IAction)を1ステップずつ実行して Right<Response> になるまで回します。
+// static http::Response
+// RunToResponse(Either<IAction*, http::Response> result) {
+//     // 予防：無限ループ防止（十分大きめ）
+//     int step_guard = 1024;
+
+//     while (step_guard-- > 0) {
+//         // あなたの Either API に合わせて修正
+//         // 例1: isRight()/unwrapRight()/unwrapLeft()
+//         if (result.isRight()) {
+//             return result.unwrapRight();
+//         }
+//         IAction* act = result.unwrapLeft();
+
+//         // ---- ここだけあなたの IAction API 名に合わせてください ----
+//         // 例A: IAction::run() が Either<IAction*, Response> を返す
+//         result = act->run();
+//         // 例B: IAction::step() や IAction::execute() などなら、上の1行を置き換える
+//         // result = act->step();
+//         // result = act->execute();
+//         // --------------------------------------------------------
+
+//         // 注意：act の所有権（delete が必要か）はあなたの設計に従ってください。
+//         // フレームワーク側が管理するなら delete しないこと。
+//         // delete act; // 必要なら有効化
+//     }
+
+//     // ここに到達したら未収束
+//     ADD_FAILURE() << "Action chain did not resolve to Response (likely needs API name tweak).";
+//     const std::string msg = "Test failed: IAction chain did not reach Response";
+//     return http::ResponseBuilder()
+//         .header("Content-Type", "text/plain")
+//         .body(msg, http::kStatusInternalServerError)
+//         .build();
+// }
+
+
+// } // namespace（テスト用ユーティリティ終わり）
+
+// // ===================== テスト本体 =====================
+
+// TEST(CgiHandlerEpollTest, SimpleGet_NoHeaders) {
+//     // write(2) での EPIPE に備えて SIGPIPE を無視
+//     signal(SIGPIPE, SIG_IGN);
+
+//     TmpRoot guard = GetTmpRoot();
+
+// #if WS_HAVE_FS
+//     const std::string dirPath = guard.path.string();
+//     const std::string cgiPath = (guard.path / "hello.cgi").string();
+// #else
+//     const std::string dirPath = guard.path;
+//     const std::string cgiPath = dirPath + "/hello.cgi";
+// #endif
+
+//     // 1) テスト用 CGI を作成（ヘッダ無しの "hello" を出力）
+//     ASSERT_TRUE(WriteTextFile(cgiPath,
+//         "#!/usr/bin/env sh\n"
+//         "printf 'hello'"));
+//     ASSERT_TRUE(MakeExecutable(cgiPath));
+
+//     // 2) 一時 conf を作成（あなたのパーサ仕様に合わせて調整可）
+// #if WS_HAVE_FS
+//     const std::string confPath = (fs::temp_directory_path() / "ws_conf_test.conf").string();
+// #else
+//     const std::string confPath = "/tmp/ws_conf_test.conf";
+// #endif
+
+//     {
+//         std::ostringstream oss;
+//         oss << "server {\n"
+//             << "  listen 8080;\n"
+//             << "  host localhost;\n"
+//             << "  location / {\n"
+//             << "    allow_method GET;\n"
+//             << "    root " << dirPath << ";\n"
+//             << "    index index.html;\n"
+//             << "  }\n"
+//             << "}\n";
+//         ASSERT_TRUE(WriteTextFile(confPath, oss.str()));
+//     }
+
+//     // 3) 設定読み込み → ドキュメントルート取得
+//     Config config(confPath);
+//     const std::vector<ServerContext>& servers = config.getParser().getServer();
+//     ASSERT_FALSE(servers.empty()) << "no server blocks parsed";
+
+//     const std::vector<LocationContext>& locations = servers[0].getLocation();
+//     ASSERT_FALSE(locations.empty()) << "no location blocks parsed";
+
+//     const DocumentRootConfig& doc = locations[0].getDocumentRootConfig();
+//     ASSERT_EQ(doc.getRoot(), dirPath);
+
+//     // 4) ハンドラとリクエストの用意
+//     http::CgiHandler handler(doc);
+
+//     RawHeaders headers;           // 実装に合わせて適宜初期化
+//     std::vector<char> body;       // 今回は空
+//     http::Request req(http::kMethodGet,
+//                       "/hello.cgi",     // request target（path）
+//                       "/hello.cgi",     // normalized path が別なら合わせて
+//                       "",               // query などがあれば指定
+//                       headers,
+//                       body,
+//                       /*server*/ NULL,
+//                       /*location*/ &locations[0]);
+
+//     // 5) 実行：公開 API の serve(...) を呼ぶ
+//     const Either<IAction*, http::Response> result = handler.serve(req);
+//     const http::Response resp = TakeRightOrFail(result); // Right 前提
+
+//     // 6) 検証
+//     EXPECT_EQ(resp.getStatusCode(), http::kStatusOk);
+//     EXPECT_EQ(GetHeader(resp, "content-type"), "text/plain");
+//     EXPECT_EQ(GetHeader(resp, "content-length"), "5");
+//     EXPECT_EQ(GetBody(resp), "hello");
+
+//     // 7) 一時 conf の掃除（repo の tmp は残す）
+//     std::remove(confPath.c_str());
+// }

--- a/test/http/handler/file/upload_test.cpp
+++ b/test/http/handler/file/upload_test.cpp
@@ -54,6 +54,7 @@ protected:
 TEST_F(UploadFileHandlerTest, UploadsFileSuccessfully) {
     DocumentRootConfig config;
     config.setRoot(tempDir);
+    config.setEnabelUpload(ON);
 
     UploadFileHandler handler(config);
 
@@ -98,6 +99,7 @@ TEST_F(UploadFileHandlerTest, Returns403IfFileCannotBeOpened) {
 TEST_F(UploadFileHandlerTest, Returns404IfDirectoryDoesNotExist) {
     DocumentRootConfig config;
     config.setRoot("nonexistent_dir");
+    config.setEnabelUpload(ON);
     UploadFileHandler handler(config);
 
     RawHeaders headers;

--- a/test/http/handler/file/upload_test.cpp
+++ b/test/http/handler/file/upload_test.cpp
@@ -54,7 +54,7 @@ protected:
 TEST_F(UploadFileHandlerTest, UploadsFileSuccessfully) {
     DocumentRootConfig config;
     config.setRoot(tempDir);
-    config.setEnabelUpload(ON);
+    config.setEnableUpload(ON);
 
     UploadFileHandler handler(config);
 
@@ -99,7 +99,7 @@ TEST_F(UploadFileHandlerTest, Returns403IfFileCannotBeOpened) {
 TEST_F(UploadFileHandlerTest, Returns404IfDirectoryDoesNotExist) {
     DocumentRootConfig config;
     config.setRoot("nonexistent_dir");
-    config.setEnabelUpload(ON);
+    config.setEnableUpload(ON);
     UploadFileHandler handler(config);
 
     RawHeaders headers;


### PR DESCRIPTION
## 概要 / Overview

- CgiHandlerの cgi_excute.cpp をepoll対応し変更しました

## 該当する issue

- #122 

## 変更内容

executeCgi()のparentProcess()をepoll対応に書き換えました

```
// parent process
bool parentProcess(pid_t pid, int wfd, int rfd, const std::vector<char>& body,
                   std::string* out, int* exitCode) {
    if (out == NULL || exitCode == NULL) {
        return false;
    }
    CgiIoCtx ctx;
    if (!initCtx(&ctx, pid, wfd, rfd, body, out)) {
        safeClose(&wfd);
        safeClose(&rfd);
        int status = 0;
        (void)waitpid(pid, &status, 0);
        return false;
    }
    // 
    bool ok = ioLoop(&ctx);
    *exitCode = ctx.exitCode;
    safeClose(&ctx.epfd);
    return ok;
}

// utils for parent process
bool initCtx(CgiIoCtx* ctx, pid_t pid, int wfd, int rfd,
            const std::vector<char>& body, std::string* out) {
    ctx->epfd = epoll_create1(EPOLL_CLOEXEC);
    if (ctx->epfd < 0) {
        return false;
    }
    ctx->pid = pid;
    ctx->wfd = wfd;
    ctx->rfd = rfd;
    ctx->wPtr = body.empty() ? NULL : &body[0];
    ctx->wRemain = static_cast<ssize_t>(body.size());
    ctx->wClosed = (ctx->wRemain == 0);
    ctx->rClosed = false;
    ctx->elapsed = 0;
    ctx->exitCode = 0;
    ctx->out = out;
    out->clear();
    out->reserve(kReserve);
    (void)setNonblock(ctx->rfd);
    (void)setNonblock(ctx->wfd);
    if (!registerEpoll(ctx)) {
        safeClose(&ctx->epfd);
        return false;
    }
    return true;
}

// helper for initCtx
bool setNonblock(int fd) {
    if (fd < 0) {
        return false;
    }
    int flags = fcntl(fd, F_GETFL, 0);
    if (flags < 0) {
        return false;
    }
    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
}

// helper for initCtx
bool registerEpoll(CgiIoCtx* ctx) {
    bool wOk = true;
    bool rOk = true;
    struct epoll_event event;

    // epollに監視を登録「書けるようになったら通知して」
    if (!ctx->wClosed && ctx->wfd >= 0) {
        memset(&event, 0, sizeof(event));
        event.events = EPOLLOUT;
        event.data.fd = ctx->wfd;
        wOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->wfd, &event) == 0); 
    }
    // epollに監視を登録「読めるようになったら通知して」
    if (!ctx->rClosed && ctx->rfd >= 0) {
        memset(&event, 0, sizeof(event));
        event.events = EPOLLIN;
        event.data.fd = ctx->rfd;
        rOk = (epoll_ctl(ctx->epfd, EPOLL_CTL_ADD, ctx->rfd, &event) == 0); 
    }
    if (ctx->wClosed) {
        safeClose(&ctx->wfd);
    }
    return wOk && rOk;
}

// epoll 駆動で CGI 子プロセスとの I/O を完了/失敗まで進めるメインループ。
//   - stepOnce() を繰り返し呼び、rfd を読み切り & wfd を書き切るまで継続
//   - 途中で stepOnce() が false を返したらタイムアウト/異常として false を返す
//   - 正常終了時は waitpid() で子を回収し、ctx->exitCode を確定
// Returns:
//   true  = 正常終了（I/O 完了→wait まで完了）
//   false = タイムアウト等で中断（kill は呼び出し側で実施）
// Side effects:
//   ctx->out に出力を蓄積, ctx->rClosed/wClosed/exitCode を更新
bool ioLoop(CgiIoCtx* ctx) {
    while (!ctx->rClosed || !ctx->wClosed) {
        // epoll 駆動の “I/Oポンプ” の1回分
        if (!stepOnce(ctx)) {
            return false;
        }
    }
    int status = 0;
    (void)waitpid(ctx->pid, &status, 0);
    if (ctx->exitCode == 0) {
        if (WIFEXITED(status)) {
            ctx->exitCode = WEXITSTATUS(status);
            return true;
        }
        if (WIFSIGNALED(status)) {
            ctx->exitCode = STATUS128 + WTERMSIG(status);
            return true;
        }
        ctx->exitCode = -1;
    }
    return true;
}

// CGI 子プロセスとのノンブロッキング入出力を “1ステップ” だけ進めるための関数
bool stepOnce(CgiIoCtx* ctx) {
    // rfd と wfd の“準備完了イベント”を受け取るためのバッファ
    epoll_event evs[2];
    int readyEvents = epoll_wait(ctx->epfd, evs, 2, kStepMs);

    if (readyEvents < 0) {
        return true;
    }
    if (readyEvents == 0) {
        ctx->elapsed += kStepMs;
        // アイドル（無イベント）状態の総時間で CGI をタイムアウトさせる
        if (ctx->elapsed >= kTotalMs) {
            safeClose(&ctx->rfd);
            safeClose(&ctx->wfd);
            return false;
        }
        return true; // イベントなしはここで1ステップ終了
    }
    ctx->elapsed = 0; // イベントが来たらリセット
    for (int i = 0; i < readyEvents; ++i) {
        // イベントが起きたFD
        int fd = evs[i].data.fd;
        // 何の種類のイベントが起きたかのビットマスク
        unsigned int events = evs[i].events; 
        proceedEvent(ctx, fd, events);
    }
    checkChild(ctx);
    return true;
}

// helper function for stepOnce
void proceedEvent(CgiIoCtx* ctx, int fd, unsigned int events) {
    if (fd == ctx->rfd && (events & EPOLLIN)) { // 読み
        handleRead(ctx);
    }
    if (fd == ctx->wfd && (events & EPOLLOUT)) { // 書き
        handleWrite(ctx);
    }
    // rfd: EPOLLINが無いときだけHUP/ERRで閉じる（読み残し保護）
    if (fd == ctx->rfd && !(events & EPOLLIN) && 
        (events & (EPOLLERR | EPOLLHUP))) {
        closeAndSet(ctx, fd);
    }
    // wfd: HUP/ERRなら即クローズ
    if (fd == ctx->wfd && (events & (EPOLLHUP | EPOLLERR))) {
        closeAndSet(ctx, fd);
    }
}

// 読む
void handleRead(CgiIoCtx* ctx) {
    char buf[kBufSize];
    ssize_t byte = ::read(ctx->rfd, buf, sizeof(buf));
    if (byte > 0) {
        ctx->out->append(buf, static_cast<std::size_t>(byte));
        return;
    }
    if (byte == 0) { // EOF
        safeClose(&ctx->rfd);
        ctx->rClosed = true;
    }
    // n < 0 は何もしない（errno は見ない）
}

// 書く
void handleWrite(CgiIoCtx* ctx) {
    if (ctx->wRemain <= 0) {
        if (!ctx->wClosed) {
            safeClose(&ctx->wfd);
            ctx->wClosed = true;
        }
        return;
    }
    ssize_t byte = ::write(ctx->wfd, ctx->wPtr, static_cast<std::size_t>(ctx->wRemain));
    if (byte > 0) {
        ctx->wPtr += byte;
        ctx->wRemain -= byte;
        if (ctx->wRemain <= 0) {
            safeClose(&ctx->wfd);
            ctx->wClosed = true;
        }
    }
    // byte <= 0 は何もしない（errno は見ない）
}

// helper for proceedEvent
void closeAndSet(CgiIoCtx* ctx, int fd) {
    if (fd == ctx->rfd) {
        safeClose(&ctx->rfd);
        ctx->rClosed = true;
    }
    if (fd == ctx->wfd) {
        safeClose(&ctx->wfd);
        ctx->wClosed = true;
    } 
}

// helper for stepOnce
void checkChild(CgiIoCtx* ctx) {
    int status = 0;
    pid_t got = waitpid(ctx->pid, &status, WNOHANG);
    if (got != ctx->pid) {
        return;
    }
    if (WIFEXITED(status)) {
        ctx->exitCode = WEXITSTATUS(status);
        return;
    }
    if (WIFSIGNALED(status)) {
        ctx->exitCode = STATUS128 + WTERMSIG(status);
        return;
    }
    ctx->exitCode = -1;
}
```


## 影響範囲
- http/handler/cgi_execute.cpp

## その他
