### PR TITLE
changed config/parser.cpp

### DIFF
--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -30,7 +30,8 @@ server {
 }
 
 server {
-  listen 80;
+  # listen 80;
+  listen 8080;
   host local;
   server_names www.webserv.com webserv.com;
 

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -101,8 +101,12 @@ void ConfigParser::setPort_(ServerContext& server, size_t& index) {
 
     if (this->tokens_[index].getType() == VALUE &&
         Validator::number(portNumber, LISTEN)) {
+            if (server.getListen() != 0) {
+                throwErr(portNumber, 
+                    ": Multiple ports on a single virtual server are not supported: line",
+                    this->tokens_[index].getLineNumber());
+            }
         server.setListen(static_cast<u_int16_t>(atoi(portNumber.c_str())));
-
     } else {
         throwErr(portNumber, ": port value error: line",
                  this->tokens_[index].getLineNumber());

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -20,12 +20,13 @@ void (ConfigParser::* ConfigParser::funcServer_[FUNC_SERVER_SIZE])(
 
 void (ConfigParser::* ConfigParser::funcLocation_[FUNC_LOCATION_SIZE])(
     LocationContext&, size_t&) = {
-    &ConfigParser::setRoot_,  &ConfigParser::setMethod_,
-    &ConfigParser::setIndex_, &ConfigParser::setAutoIndex_,
-    &ConfigParser::setIsCgi_, &ConfigParser::setRedirect_,
+    &ConfigParser::setRoot_,        &ConfigParser::setMethod_,
+    &ConfigParser::setIndex_,       &ConfigParser::setAutoIndex_,
+    &ConfigParser::setIsCgi_,       &ConfigParser::setRedirect_,
     &ConfigParser::setEnableUpload_};
 
-ConfigParser::ConfigParser(ConfigTokenizer& tokenizer, const std::string& confFile)
+ConfigParser::ConfigParser(ConfigTokenizer& tokenizer,
+                           const std::string& confFile)
     : tokens_(tokenizer.getTokens()), depth_(0), confFile_(confFile) {
     makeVectorServer_();
 }
@@ -48,7 +49,8 @@ void ConfigParser::makeVectorServer_() {
                          tokens_[i].getLineNumber());
             }
             addServer_(i);
-        } else if ((type >= LISTEN && type <= ENABLE_UPLOAD) && this->depth_ == 0) {
+        } else if ((type >= LISTEN && type <= ENABLE_UPLOAD) &&
+                   this->depth_ == 0) {
             throwErr(this->tokens_[i].getText(), ": Syntax error: line",
                      tokens_[i].getLineNumber());
         } else {
@@ -101,11 +103,12 @@ void ConfigParser::setPort_(ServerContext& server, size_t& index) {
 
     if (this->tokens_[index].getType() == VALUE &&
         Validator::number(portNumber, LISTEN)) {
-            if (server.getListen() != 0) {
-                throwErr(portNumber, 
-                    ": Multiple ports on a single virtual server are not supported: line",
-                    this->tokens_[index].getLineNumber());
-            }
+        if (server.getListen() != 0) {
+            throwErr(portNumber,
+                     ": Multiple ports on a single virtual server are not "
+                     "supported: line",
+                     this->tokens_[index].getLineNumber());
+        }
         server.setListen(static_cast<u_int16_t>(atoi(portNumber.c_str())));
     } else {
         throwErr(portNumber, ": port value error: line",


### PR DESCRIPTION
## 概要 / Overview

- configで１つのserverブロック内に複数のlistenポートがある場合は弾く

## 該当する issue

- #127 

## 変更内容

- 現状

```
void ConfigParser::setPort_(ServerContext& server, size_t& index) {
    const std::string portNumber = incrementAndCheckSize_(index);

    if (this->tokens_[index].getType() == VALUE &&
        Validator::number(portNumber, LISTEN)) {
        server.setListen(static_cast<u_int16_t>(atoi(portNumber.c_str())));
    } else {
        throwErr(portNumber, ": port value error: line",
                 this->tokens_[index].getLineNumber());
    }
}
```

- 変更後
```
void ConfigParser::setPort_(ServerContext& server, size_t& index) {
    const std::string portNumber = incrementAndCheckSize_(index);

    if (this->tokens_[index].getType() == VALUE &&
        Validator::number(portNumber, LISTEN)) {
           → if (server.getListen() != 0) {
           →     throwErr(portNumber, 
           →         ": Multiple ports on a single virtual server are not supported: line",
           →         this->tokens_[index].getLineNumber());
           → }
        server.setListen(static_cast<u_int16_t>(atoi(portNumber.c_str())));
    } else {
        throwErr(portNumber, ": port value error: line",
                 this->tokens_[index].getLineNumber());
    }
}
```
初期設定が０なのでportに既に値が入っている場合はエラーを表示して終了します


- 変更点
  - xxxxxx
  - xxxxxx
  - xxxxxx

## 影響範囲
- xxxxxx
- xxxxxx

## その他
