### PR TITLE
fixed include path other than http folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,71 @@ CPP	= c++
 CPPFLAG	= -Wall -Wextra -Wall -std=c++98 -pedantic
 # CPPFLAG += -g -fsanitize=address
 INC_DIR	= include
-SRCS	= src/main.cpp \
-	  src/config/Config.cpp \
-	  src/config/ServerContext.cpp \
-	  src/config/LocationContext.cpp \
-	  src/config/DocumentRootConfig.cpp \
-	  src/validator/Validator.cpp \
-	  src/config/ConfigTokenizer.cpp \
-	  src/config/ConfigParser.cpp \
-	  src/config/Token.cpp
+SRCS	= 	src/config/tokenizer.cpp \
+	src/config/context/locationContext.cpp \
+	src/config/context/documentRootConfig.cpp \
+	src/config/context/serverContext.cpp \
+	src/config/validator.cpp \
+	src/config/config.cpp \
+	src/config/testPrint.cpp \
+	src/config/token.cpp \
+	src/config/parser.cpp \
+	src/utils/logger.cpp \
+	src/utils/string.cpp \
+	src/http/method.cpp \
+	src/http/request/read/utils.cpp \
+	src/http/request/read/body.cpp \
+	src/http/request/read/chunked_body.cpp \
+	src/http/request/read/header.cpp \
+	src/http/request/read/header_parsing_utils.cpp \
+	src/http/request/read/length_body.cpp \
+	src/http/request/read/line.cpp \
+	src/http/request/read/context.cpp \
+	src/http/request/read/reader.cpp \
+	src/http/request/parse/request_parser.cpp \
+	src/http/request/request.cpp \
+	src/http/handler/file/delete.cpp \
+	src/http/handler/file/redirect.cpp \
+	src/http/handler/file/static.cpp \
+	src/http/handler/file/cgi_env.cpp \
+	src/http/handler/file/cgi_execute.cpp \
+	src/http/handler/file/cgi_parse.cpp \
+	src/http/handler/file/cgi_target.cpp \
+	src/http/handler/file/cgi.cpp \
+	src/http/handler/file/upload.cpp \
+	src/http/handler/router/builder.cpp \
+	src/http/handler/router/internal.cpp \
+	src/http/handler/router/middleware/chain.cpp \
+	src/http/handler/router/middleware/error_page.cpp \
+	src/http/handler/router/middleware/logger.cpp \
+	src/http/handler/router/registry.cpp \
+	src/http/handler/router/router.cpp \
+	src/http/mime.cpp \
+	src/http/response/builder.cpp \
+	src/http/response/response.cpp \
+	src/http/response/response_headers.cpp \
+	src/http/status.cpp \
+	src/http/virtual_server.cpp \
+	src/io/base/fileDescriptor.cpp \
+	src/io/input/read/buffer.cpp \
+	src/io/input/reader/fd.cpp \
+	src/io/input/write/buffer.cpp \
+	src/io/handler/CgiStdinHandler.cpp \
+	src/io/handler/CgiStdoutHandler.cpp \
+	src/io/handler/ListenerHandler.cpp \
+	src/io/handler/ClientHandler.cpp \
+	src/server/socket/connectionSocket.cpp \
+	src/server/socket/serverSocket.cpp \
+	src/server/socket/socketAddr.cpp \
+	src/server/connection/connectionManager.cpp \
+	src/server/connection/connection.cpp \
+	src/server/epollEvent.cpp \
+	src/server/fileDescriptor/fdRegistry.cpp \
+	src/server/dispatcher/requestDispatcher.cpp \
+	src/server/epollEventNotifier.cpp \
+	src/server/resolver/endpointResolver.cpp \
+	src/server/server.cpp \
+	src/main.cpp
 
 OBJS	= $(SRCS:.cpp=.o)
 

--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -7,10 +7,10 @@ class ConfigTokenizer;
 #include <algorithm>
 #include <string>
 
-#include "locationContext.hpp"
-#include "parser.hpp"
-#include "serverContext.hpp"
-#include "status.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/parser.hpp"
+#include "config/context/serverContext.hpp"
+#include "http/status.hpp"
 
 #define FILE_NAME "./config_file/default.conf"
 

--- a/include/config/context/documentRootConfig.hpp
+++ b/include/config/context/documentRootConfig.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <iostream>
-#include "data.hpp"
-#include "parser.hpp"
-#include "token.hpp"
+#include "config/data.hpp"
+#include "config/parser.hpp"
+#include "config/token.hpp"
 
 class DocumentRootConfig {
    public:

--- a/include/config/context/locationContext.hpp
+++ b/include/config/context/locationContext.hpp
@@ -2,11 +2,11 @@
 
 #include <iostream>
 
-#include "data.hpp"
-#include "documentRootConfig.hpp"
-#include "parser.hpp"
-#include "token.hpp"
-#include "method.hpp"
+#include "config/data.hpp"
+#include "config/context/documentRootConfig.hpp"
+#include "config/parser.hpp"
+#include "config/token.hpp"
+#include "http/method.hpp"
 
 typedef std::vector<LocationContext> LocationContextList;
 

--- a/include/config/context/serverContext.hpp
+++ b/include/config/context/serverContext.hpp
@@ -10,11 +10,11 @@ class LocationContext;
 #include <map>
 #include <vector>
 
-#include "documentRootConfig.hpp"
-#include "locationContext.hpp"
-#include "token.hpp"
-#include "tokenizer.hpp"
-#include "status.hpp"
+#include "config/context/documentRootConfig.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/token.hpp"
+#include "config/tokenizer.hpp"
+#include "http/status.hpp"
 
 class ServerContext {
    public:

--- a/include/config/parser.hpp
+++ b/include/config/parser.hpp
@@ -7,8 +7,8 @@ class ServerContext;
 
 #include <vector>
 
-#include "token.hpp"
-#include "tokenizer.hpp"
+#include "config/token.hpp"
+#include "config/tokenizer.hpp"
 
 class ConfigParser {
    public:

--- a/include/config/tokenizer.hpp
+++ b/include/config/tokenizer.hpp
@@ -9,7 +9,7 @@ class Token;
 #include <string>
 #include <vector>
 
-#include "token.hpp"
+#include "config/token.hpp"
 
 #define FILE_NAME "./config_file/default.conf"
 

--- a/include/http/handler/file/delete.hpp
+++ b/include/http/handler/file/delete.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "handler.hpp"
+#include "handler/handler.hpp"
 #include "config/config.hpp"
 
 namespace http {

--- a/include/http/handler/file/redirect.hpp
+++ b/include/http/handler/file/redirect.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "handler.hpp"
+#include "http/handler/handler.hpp"
 
 namespace http {
     class RedirectHandler : public IHandler {

--- a/include/http/handler/file/static.hpp
+++ b/include/http/handler/file/static.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "handler.hpp"
+#include "http/handler/handler.hpp"
 #include "config/config.hpp"
-#include "result.hpp"
+#include "utils/types/result.hpp"
 
 namespace http {
 

--- a/include/http/handler/file/upload.hpp
+++ b/include/http/handler/file/upload.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "config/config.hpp"
-#include "either.hpp"
-#include "handler.hpp"
+#include "utils/types/either.hpp"
+#include "http/handler/handler.hpp"
 #include "http/response/response.hpp"
-#include "result.hpp"
+#include "utils/types/result.hpp"
 
 static const unsigned char kAsciiSpace = 0x20;
 

--- a/include/http/handler/handler.hpp
+++ b/include/http/handler/handler.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "http/request/request.hpp"
-#include "either.hpp"
+#include "utils/types/either.hpp"
 #include "action/action.hpp"
 #include "http/response/response.hpp"
 

--- a/include/http/handler/matcher.hpp
+++ b/include/http/handler/matcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "option.hpp"
+#include "utils/types/option.hpp"
 #include "utils/string.hpp"
 #include <map>
 #include <string>

--- a/include/http/handler/router/middleware/middleware.hpp
+++ b/include/http/handler/router/middleware/middleware.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "action.hpp"
-#include "handler.hpp"
+#include "action/action.hpp"
+#include "http/handler/handler.hpp"
 
 namespace http {
     class IMiddleware {

--- a/include/http/handler/router/registry.hpp
+++ b/include/http/handler/router/registry.hpp
@@ -2,9 +2,9 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include "method.hpp"
-#include "option.hpp"
-#include "matcher.hpp"
+#include "http/method.hpp"
+#include "utils/types/option.hpp"
+#include "http/handler/matcher.hpp"
 #include "handler/handler.hpp"
 
 namespace http {

--- a/include/http/handler/router/router.hpp
+++ b/include/http/handler/router/router.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "internal.hpp"
+#include "http/handler/router/internal.hpp"
 #include "middleware/chain.hpp"
 
 namespace http {

--- a/include/http/method.hpp
+++ b/include/http/method.hpp
@@ -13,7 +13,7 @@ namespace http {
         kMethodOptions,
         kMethodTrace,
         kMethodConnect,
-        kMethodPatch,
+        kMethodPatch
     };
 
     HttpMethod httpMethodFromString(const std::string &method);

--- a/include/http/request/read/body.hpp
+++ b/include/http/request/read/body.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "buffer.hpp"
-#include "state.hpp"
-#include "chunked_body.hpp"
+#include "io/input/write/buffer.hpp"
+#include "http/request/read/state.hpp"
+#include "http/request/read/chunked_body.hpp"
 
 namespace http {
 

--- a/include/http/request/read/chunked_body.hpp
+++ b/include/http/request/read/chunked_body.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "buffer.hpp"
-#include "context.hpp"
-#include "state.hpp"
+#include "io/input/read/buffer.hpp"
+#include "http/request/read/context.hpp"
+#include "http/request/read/state.hpp"
 
 namespace http {
 

--- a/include/http/request/read/header.hpp
+++ b/include/http/request/read/header.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include "buffer.hpp"
-#include "context.hpp"
-#include "state.hpp"
+#include "io/input/read/buffer.hpp"
+#include "http/request/read/context.hpp"
+#include "http/request/read/state.hpp"
 
 namespace http {
 

--- a/include/http/request/read/header_parsing_utils.hpp
+++ b/include/http/request/read/header_parsing_utils.hpp
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "body.hpp"
-#include "raw_headers.hpp"
+#include "http/request/read/body.hpp"
+#include "http/request/read/raw_headers.hpp"
 
 namespace http {
 namespace parser {

--- a/include/http/status.hpp
+++ b/include/http/status.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include "option.hpp"
+#include "utils/types/option.hpp"
 
 namespace http {
     enum HttpStatusCode {
@@ -75,7 +75,7 @@ namespace http {
         kStatusInsufficientStorage = 507,
         kStatusLoopDetected = 508,
         kStatusNotExtended = 510,
-        kStatusNetworkAuthenticationRequired = 511,
+        kStatusNetworkAuthenticationRequired = 511
     };
 
     types::Option<http::HttpStatusCode> httpStatusCodeFromInt(int code);

--- a/include/io/input/read/buffer.hpp
+++ b/include/io/input/read/buffer.hpp
@@ -19,6 +19,8 @@ public:
     typedef types::Result<std::size_t, error::AppError> LoadResult;
     LoadResult load();
     size_t size() const;
+    // LoadResult ReadBuffer::fillAvailable();
+
 
 private:
     std::vector<char> buf_;

--- a/include/io/input/reader/reader.hpp
+++ b/include/io/input/reader/reader.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "result.hpp"
-#include "error.hpp"
+#include "utils/types/result.hpp"
+#include "utils/types/error.hpp"
 
 namespace io {
     class IReader {

--- a/include/utils/types/error.hpp
+++ b/include/utils/types/error.hpp
@@ -13,6 +13,6 @@ namespace error {
         kHasContentLengthAndTransferEncoding,
         kcontainsNonDigit,
         kBadLocationContext,
-        kUriTooLong,
+        kUriTooLong
     };
 } // namespace error

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -3,10 +3,10 @@
 #include <cstddef>
 #include <string>
 
-#include "data.hpp"
-#include "documentRootConfig.hpp"
-#include "locationContext.hpp"
-#include "serverContext.hpp"
+#include "config/data.hpp"
+#include "config/context/documentRootConfig.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/context/serverContext.hpp"
 
 namespace {
 static std::string normalizeHostKey(const std::string& host) {

--- a/src/config/context/documentRootConfig.cpp
+++ b/src/config/context/documentRootConfig.cpp
@@ -1,4 +1,4 @@
-#include "documentRootConfig.hpp"
+#include "config/context/documentRootConfig.hpp"
 
 DocumentRootConfig::DocumentRootConfig()
     : index_("index.html"), autoIndex_(OFF), cgiExtensions_(OFF), enableUpload_(OFF) {

--- a/src/config/context/locationContext.cpp
+++ b/src/config/context/locationContext.cpp
@@ -1,8 +1,7 @@
-#include "locationContext.hpp"
+#include "config/context/locationContext.hpp"
 
 #include <string>
-
-#include "data.hpp"
+#include "config/data.hpp"
 
 LocationContext::LocationContext(const std::string& text) : value_(text) {
     this->allowedMethod_[GET] = OFF;

--- a/src/config/context/serverContext.cpp
+++ b/src/config/context/serverContext.cpp
@@ -1,4 +1,4 @@
-#include "serverContext.hpp"
+#include "config/context/serverContext.hpp"
 
 ServerContext::ServerContext(const std::string& text)
     : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("127.0.0.1") {

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -5,12 +5,12 @@
 #include <cstddef>
 #include <stdexcept>
 
-#include "config.hpp"
-#include "locationContext.hpp"
-#include "serverContext.hpp"
-#include "token.hpp"
-#include "tokenizer.hpp"
-#include "validator.hpp"
+#include "config/config.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/context/serverContext.hpp"
+#include "config/token.hpp"
+#include "config/tokenizer.hpp"
+#include "config/validator.hpp"
 
 void (ConfigParser::* ConfigParser::funcServer_[FUNC_SERVER_SIZE])(
     ServerContext&, size_t&) = {

--- a/src/config/testPrint.cpp
+++ b/src/config/testPrint.cpp
@@ -1,10 +1,10 @@
 #include <cstddef>
 
 #include "config/config.hpp"
-#include "data.hpp"
-#include "documentRootConfig.hpp"
-#include "locationContext.hpp"
-#include "serverContext.hpp"
+#include "config/data.hpp"
+#include "config/context/documentRootConfig.hpp"
+#include "config/context/locationContext.hpp"
+#include "config/context/serverContext.hpp"
 
 void Config::printServer(const std::vector<ServerContext>& server) {
     for (size_t i = 0; i < server.size(); ++i) {

--- a/src/config/token.cpp
+++ b/src/config/token.cpp
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "parser.hpp"
-#include "tokenizer.hpp"
+#include "config/parser.hpp"
+#include "config/tokenizer.hpp"
 
 Token::Token(const std::string& text, int lineNumber, TokenPosition position)
     : text_(text), lineNumber_(lineNumber), position_(position) {

--- a/src/config/tokenizer.cpp
+++ b/src/config/tokenizer.cpp
@@ -1,4 +1,4 @@
-#include "tokenizer.hpp"
+#include "config/tokenizer.hpp"
 
 #include <fstream>
 #include <sstream>

--- a/src/config/validator.cpp
+++ b/src/config/validator.cpp
@@ -1,10 +1,10 @@
-#include "validator.hpp"
+#include "config/validator.hpp"
 
 #include <unistd.h>
 
 #include <stdexcept>
 
-#include "token.hpp"
+#include "config/token.hpp"
 
 bool Validator::number(const std::string& number, int type) {
     for (size_t i = 0; i < number.size(); ++i) {

--- a/src/io/input/read/buffer.cpp
+++ b/src/io/input/read/buffer.cpp
@@ -1,4 +1,4 @@
-#include "buffer.hpp"
+#include "io/input/read/buffer.hpp"
 #include "utils/types/try.hpp"
 #include <string>
 #include <algorithm>
@@ -69,3 +69,28 @@ size_t ReadBuffer::size() const {
 // 低レベルなリーダーIReaderからバッファ付きで文字列を読み取るラッパー
 // ・ReadBufferはIReader(例えばFdReader)のラッパー
 // ・内部にstd::vector<char> buf_を持ち、読み込み済みのデータを一時保持する
+
+
+
+// ReadBuffer::LoadResult ReadBuffer::fillAvailable() {
+//     std::size_t total = 0;
+//     for (;;) {
+//         if (reader_.eof()) {
+//             break;
+//         }
+
+//         char tmp[kLoadSize];
+//         types::Result<std::size_t, error::AppError> r = reader_.read(tmp, kLoadSize);
+//         // if (r.isErr()) {
+//         //     // errnoを見ない設計なら基本ここに来ない（致命だけに限るならそのままerr）
+//         //     return types::err(r.unwrapErr());
+//         // }
+//         std::size_t n = r.unwrap();
+//         if (n == 0) 
+//             break;                 // 進捗なし or EOF → ここで打ち切り
+//         // チャンクの途中で打ち切りになった場合でもうまくいくのか？？
+//         buf_.insert(buf_.end(), tmp, tmp + n);
+//         total += n;
+//     }
+//     return types::ok(total);
+// }

--- a/src/server/epollEvent.cpp
+++ b/src/server/epollEvent.cpp
@@ -1,4 +1,4 @@
-#include "EpollEvent.hpp"
+#include "server/EpollEvent.hpp"
 
 EpollEvent::EpollEvent(uint32_t events, void* userData) {
     ev_.events = events;

--- a/src/server/epollEventNotifier.cpp
+++ b/src/server/epollEventNotifier.cpp
@@ -1,10 +1,10 @@
-#include "EpollEvent.hpp"
-#include "EpollEventNotifier.hpp"
+#include "server/EpollEvent.hpp"
+#include "server/EpollEventNotifier.hpp"
 #include <unistd.h>
 #include <sys/epoll.h>
 #include <string.h>
 #include <vector>
-#include "try.hpp"
+#include "utils/types/try.hpp"
 #include <cerrno> 
 EpollEventNotifier::EpollEventNotifier()
     : epoll_fd_(epoll_create(kMaxAssociatedFD)) {

--- a/src/server/fileDescriptor/fdRegistry.cpp
+++ b/src/server/fileDescriptor/fdRegistry.cpp
@@ -1,0 +1,48 @@
+#include "server/fileDescriptor/FdRegistry.hpp"
+#include <utility> // std::make_pair
+
+bool FdRegistry::add(int fd, FdKind k, Connection* c) {
+    if (fd < 0) {
+        return false;
+    }
+    std::map<int, FdEntry>::iterator it = table_.find(fd);
+    if (it != table_.end()) {
+        return false;
+    }
+    FdEntry e;
+    e.fd   = fd;
+    e.kind = k;
+    e.conn = c; // LISTENER の場合は 0 を渡す
+    table_.insert(std::make_pair(fd, e));
+    return true;
+}
+
+void FdRegistry::erase(int fd) {
+    std::map<int, FdEntry>::iterator it = table_.find(fd);
+    if (it != table_.end()) {
+        table_.erase(it);
+    }
+}
+
+bool FdRegistry::is(int fd, FdKind k) const {
+    std::map<int, FdEntry>::const_iterator it = table_.find(fd);
+    if (it == table_.end()) return false;
+    return it->second.kind == k;
+}
+
+Connection* FdRegistry::getConn(int fd) const {
+    std::map<int, FdEntry>::const_iterator it = table_.find(fd);
+    if (it == table_.end()) return 0;
+    return it->second.conn;
+}
+
+bool FdRegistry::find(int fd, FdEntry* out) const {
+    std::map<int,FdEntry>::const_iterator it = table_.find(fd);
+    if (it == table_.end()) {
+        return false;
+    }
+    if (out) {
+        *out = it->second;
+    }
+    return true;
+}

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1,0 +1,244 @@
+#include "server/Server.hpp"
+#include "utils/types/try.hpp"
+#include "server/socket/SocketAddr.hpp"
+
+
+Server::Server(const std::vector<ServerContext>& serverCtxs) 
+    : serverCtxs_(serverCtxs), 
+    epollNotifier_(), 
+    connManager_(),
+    dispatcher_(0),
+    resolver_(serverCtxs_),
+    endpointResolver_(vsByKey_) {
+    handlers_[FD_LISTENER]   = new ListenerHandler(this);
+    handlers_[FD_CLIENT]     = new ClientHandler(this);
+    handlers_[FD_CGI_STDIN]  = new CgiStdinHandler(this);
+    handlers_[FD_CGI_STDOUT] = new CgiStdoutHandler(this);
+}
+
+types::Result<types::Unit, int> Server::init() {
+    TRY(epollNotifier_.open());
+    TRY(initVirtualServers());
+    TRY(buildListeners());
+    TRY(initDispatcher());
+    return types::ok(types::Unit());
+}
+
+types::Result<types::Unit, int> Server::initVirtualServers() {
+    for (size_t i = 0; i < serverCtxs_.size(); ++i) {
+        const ServerContext& sc = serverCtxs_[i];
+
+        const std::string key = makeEndpointKeyFromConfig(sc.getHost(), sc.getListen());
+        for (std::map<std::string, VirtualServer*>::const_iterator it = vsByKey_.begin();
+             it != vsByKey_.end(); ++it) {
+            if (key == it->first || overlapsWildcard(key, it->first)) {
+                return types::err<int>(EINVAL); // ワイルドカードと重複エラー
+            }
+        }
+        VirtualServer* vs = new VirtualServer(sc, /*bindAddress=*/canonicalizeIp(sc.getHost()));
+        vsByKey_[key] = vs;
+    }
+    return types::ok();
+}
+
+// Todo: VirtualServer が複数の listen ポートを許容する場合、2 重ループにて処理する必要がある。
+types::Result<types::Unit,int> Server::buildListeners() {
+    for (size_t i = 0; i < serverCtxs_.size(); ++i) {
+        const ServerContext& sc = serverCtxs_[i];
+        ListenerKey key;
+        key.addr = canonicalizeIp(sc.getHost());
+        key.port = sc.getListen();
+        if (listeners_.find(key) != listeners_.end()) {
+            continue;
+        }
+        ServerSocket* ls = new ServerSocket();
+        types::Result<int, int> r = ls->open(AF_INET, SOCK_STREAM, 0);
+        if (r.isErr()) {
+            return types::err<int>(r.unwrapErr());
+        }
+        types::Result<int, int> r2 = ls->setReuseAddr(true);
+        if (r2.isErr()) {
+           return types::err<int>(r2.unwrapErr());
+        };
+        SocketAddr sa = SocketAddr::createIPv4(key.addr, key.port);
+        types::Result<int, int> r3 = ls->bind(sa);
+        if (r3.isErr()) {
+           return types::err<int>(r3.unwrapErr());
+        };
+        listeners_[key] = ls;
+        TRY(ls->listen(SOMAXCONN));
+        const int lfd = ls->getRawFd();
+        epollNotifier_.add(lfd, EPOLLIN | EPOLLERR);
+        fdRegister_.add(lfd, FD_LISTENER, 0);
+    }
+    return types::ok();
+}
+
+types::Result<types::Unit,int> Server::initDispatcher() {
+    dispatcher_ = new RequestDispatcher(endpointResolver_);
+    return types::ok();
+}
+
+types::Result<types::Unit,int> Server::run() {
+    for (;;) {
+        types::Result<std::vector<EpollEvent>, int> r = epollNotifier_.wait(); // 200ms など
+        if (r.isErr()) return types::err<int>(r.unwrapErr());
+
+        const std::vector<EpollEvent>& evs = r.unwrap();
+        for (size_t i = 0; i < evs.size(); ++i) {
+            const EpollEvent& ev = evs[i];
+            const int fd         = ev.getUserFd();
+            const uint32_t mask  = ev.getEvents();
+            FdEntry fdEntry;
+            if (!fdRegister_.find(fd, &fdEntry)) {
+                // epollDelClose(fd);
+                continue;
+            }
+            IFdHandler* fdEventHandler = handlers_[fdEntry.kind];
+            fdEventHandler->onEvent(fdEntry, mask);
+        }
+        // sweepTimeouts(); // ヘッダ/ボディ/CGI ごとの壁時計タイムアウトで close
+    }
+}
+
+void Server::acceptLoop(int lfd) {
+    for (;;) {
+        SocketAddr peer = SocketAddr::makeEmpty();
+        socklen_t len = peer.length();
+        int cfd = ::accept(lfd, peer.raw(), &len);
+        peer.setLength(len);
+        if (cfd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            // Todo : emit log.
+            break;
+        }
+        peer.setLength(len);
+        set_nonblock_and_cloexec(cfd);
+        Connection* conn = new Connection(cfd, peer, this->resolver());
+        connManager_.registerConnection(conn);
+        epollNotifier_.add(cfd, EPOLLIN | EPOLLRDHUP | EPOLLERR);
+        fdRegister_.add(cfd, FD_CLIENT, conn);
+    }
+}
+
+// hostNameを正規化して dotted decimal string を返す
+std::string canonicalizeIp(const std::string& hostName) {
+    if (hostName.empty() || hostName == "*" || hostName == "0.0.0.0")
+        return "0.0.0.0";
+    SocketAddr sa = SocketAddr::createIPv4(hostName, 0);
+    return sa.getAddress();
+}
+
+std::string makeEndpointKeyFromConfig(const std::string& hostName, unsigned short port) {
+    const std::string ip = canonicalizeIp(hostName);
+    return ip + ":" + u16toString(port);
+}
+
+static std::string u16toString(unsigned short port) {
+    std::ostringstream oss;
+    oss << port;
+    return oss.str();
+}
+
+http::config::IConfigResolver&  Server::resolver() { 
+    return resolver_;
+}
+
+void Server::armInOnly(int fd) {
+    epollNotifier_.mod(fd, EPOLLIN | EPOLLRDHUP | EPOLLERR);
+}
+void Server::armOutOnly(int fd) {
+    epollNotifier_.mod(fd, EPOLLOUT | EPOLLERR);
+}
+void Server::armInOut(int fd) {
+    epollNotifier_.mod(fd, EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLERR);
+}
+
+RequestDispatcher* Server::getDispatcher() const {
+    return dispatcher_;
+}
+
+void Server::applyDispatchResult(Connection& c, const DispatchResult& dr) {
+    const int cfd = c.getFd();
+    if (dr.isNone()) {
+        return;
+    }
+    if (dr.isArmOut()) {
+        epollNotifier_.mod(cfd, EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLERR);
+        return;
+    }
+    if (dr.isStartCgi()) {
+        // CGI のパイプを epoll / registry に登録
+        const int in_w  = dr.cgi.stdin_fd;   // サーバ→子に書く（OUT）
+        const int out_r = dr.cgi.stdout_fd;  // 子→サーバから読む（IN）
+        // モック（-1）のときは何もしない
+        if (in_w >= 0 && out_r >= 0) {
+            set_nonblock_and_cloexec(in_w);
+            set_nonblock_and_cloexec(out_r);
+            fdRegister_.add(in_w,  FD_CGI_STDIN,  &c);
+            fdRegister_.add(out_r, FD_CGI_STDOUT, &c);
+            epollNotifier_.add(in_w,  EPOLLOUT | EPOLLERR);
+            epollNotifier_.add(out_r, EPOLLIN  | EPOLLERR);
+        }
+        // クライアント fd 側は通常 IN を維持（必要に応じて OUT も残してOK）
+        // epollNotifier_.mod(cfd, EPOLLIN | EPOLLRDHUP | EPOLLERR);
+        return;
+    }
+    if (dr.isDone()) {
+        // CGI の後片付け：Connection から現在の CGI fd を引いて epoll/registry 解除
+        // ※ Connection に以下の getter を用意しておくと楽:
+        //    int getCgiInFd() const; int getCgiOutFd() const; bool hasCgi() const;
+        if (/* c.hasCgi() */ true) {
+            int in_w  = /* c.getCgiInFd()  */ -1;
+            int out_r = /* c.getCgiOutFd() */ -1;
+
+            if (in_w  >= 0) { 
+                epollNotifier_.del(in_w);
+                fdRegister_.erase(in_w);
+                ::close(in_w);
+            }
+            if (out_r >= 0) { 
+                epollNotifier_.del(out_r);
+                fdRegister_.erase(out_r); 
+                ::close(out_r); 
+            }
+            // c.clearCgi(); // ← Connection 側に用意しておく
+        }
+        // クライアント側は、まだ書くものがあれば OUT をアーム、無ければ IN のみ
+        if (!c.getWriteBuffer().isEmpty()) {
+            epollNotifier_.mod(cfd, EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLERR);
+        } else {
+            epollNotifier_.mod(cfd, EPOLLIN | EPOLLRDHUP | EPOLLERR);
+        }
+        return;
+    }
+    if (dr.isClose()) {
+        // クライアント接続を閉じる（必要なら関連 CGI fd も掃除）
+        // 1) CGI が生きていれば解除
+        // if (c.hasCgi()) { ... 同上の del/erase/close ...; c.clearCgi(); }
+        // 2) クライアント fd を epoll/registry から外す
+        epollNotifier_.del(cfd);
+        fdRegister_.erase(cfd);
+        // 3) ConnectionManager から外して、fd close/メモリ解放
+        connManager_.unregisterConnection(cfd);
+        return;
+    }
+}
+
+
+bool overlapsWildcard(const std::string& a, const std::string& b) {
+    size_t ca = a.find(':');
+    size_t cb = b.find(':');
+    if (ca == std::string::npos || cb == std::string::npos) {
+        return false;
+    }
+    std::string ipa = a.substr(0, ca);
+    std::string ipb = b.substr(0, cb);
+    if (a.substr(ca+1) != b.substr(cb+1)) {
+        return false;
+    }
+    // 同じポートで、どちらかが 0.0.0.0
+    return (ipa == "0.0.0.0") || (ipb == "0.0.0.0");
+}

--- a/src/server/socket/connectionSocket.cpp
+++ b/src/server/socket/connectionSocket.cpp
@@ -1,4 +1,4 @@
-#include "ConnectionSocket.hpp"
+#include "server/socket/ConnectionSocket.hpp"
 
 ConnectionSocket::ConnectionSocket(int fd, const ISocketAddr& peerAddr) 
     : fd_(fd),

--- a/src/server/socket/serverSocket.cpp
+++ b/src/server/socket/serverSocket.cpp
@@ -1,4 +1,4 @@
-#include "ServerSocket.hpp"
+#include "server/socket/ServerSocket.hpp"
 #include "utils/types/result.hpp"
 #include <cerrno>
 #include <iostream>

--- a/src/server/socket/socketAddr.cpp
+++ b/src/server/socket/socketAddr.cpp
@@ -1,4 +1,4 @@
-#include "SocketAddr.hpp"
+#include "server/socket/SocketAddr.hpp"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -1,4 +1,4 @@
-#include "logger.hpp"
+#include "utils/logger.hpp"
 #include <iostream>
 #include <ctime>
 

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -1,4 +1,4 @@
-#include "string.hpp"
+#include "utils/string.hpp"
 
 #include <cctype>
 #include <vector>


### PR DESCRIPTION
## 概要 / Overview
- include pathのアップデートを行いました。


## 該当する issue

- #130 

## 変更内容
make を行う際に、header ファイルや、cpp ファイルの中の include に当たる部分の相対パスを正しく補完しました。
## 影響範囲
- http フォルダを除く cpp 及び hpp ファイル

## その他
関連する issue #129 