### PR TITLE
155 bug under 1024 port error

### DIFF
--- a/include/config/validator.hpp
+++ b/include/config/validator.hpp
@@ -11,6 +11,7 @@ class Token;
 
 enum { DIRECTORY, FILENAME };
 
+static const int MIN_PORT = 1024;
 static const int MAX_PORT = 65535;
 static const int MAX_BODY_SIZE = 1000000;
 static const int MIN_PAGE_NUM = 100;

--- a/src/config/context/serverContext.cpp
+++ b/src/config/context/serverContext.cpp
@@ -1,7 +1,7 @@
 #include "config/context/serverContext.hpp"
 
 ServerContext::ServerContext(const std::string& text)
-    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("127.0.0.1") {
+    : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("localhost") {
     // std::map<http::HttpStatusCode, std::string> errPage;
     // errPage.insert(std::make_pair(http::kStatusNotFound, "404.html"));
     // this->errorPage_.push_back(errPage);

--- a/src/config/validator.cpp
+++ b/src/config/validator.cpp
@@ -16,7 +16,7 @@ bool Validator::number(const std::string& number, int type) {
     const int num = atoi(number.c_str());
 
     if (type == LISTEN) {
-        return (num >= 0 && num <= MAX_PORT);
+        return (num >= MIN_PORT && num <= MAX_PORT);
     }
     if (type == MAX_SIZE) {
         return (num > 0 && num <= MAX_BODY_SIZE);

--- a/test/config/parser_test.cpp
+++ b/test/config/parser_test.cpp
@@ -521,7 +521,7 @@ server {
 TEST_F(ConfigParserTest, NoHostInServerError) {
     std::string configText = R"(
 server {
-    listen 80;
+    listen 8080;
     location / {
         root /;
         index index.html;
@@ -562,7 +562,7 @@ server {
 TEST_F(ConfigParserTest, NoLocationInServerError) {
     std::string configText = R"(
 server {
-    listen 80;
+    listen 8080;
     host localhost;
 }
 )";
@@ -600,7 +600,7 @@ server {
 TEST_F(ConfigParserTest, NoRootInLocationError) {
     std::string configText = R"(
 server {
-    listen 80;
+    listen 8080;
     host localhost;
     location / {
         index index.html;
@@ -641,7 +641,7 @@ server {
 TEST_F(ConfigParserTest, NoIndexInLocationError) {
     std::string configText = R"(
 server {
-    listen 80;
+    listen 8080;
     host localhost;
     location / {
         root /;

--- a/test/config/parser_test.cpp
+++ b/test/config/parser_test.cpp
@@ -251,6 +251,21 @@ server {
         { ConfigParser parser(*tokenizer, filename); }, std::runtime_error);
 }
 
+// Test error handling - invalid port number
+TEST_F(ConfigParserTest, InvalidPortNumberError4) {
+    std::string config = R"(
+server {
+    listen 80;
+}
+)";
+
+    std::string filename;
+    ConfigTokenizer* tokenizer = makeTok(config, filename);
+
+    EXPECT_THROW(
+        { ConfigParser parser(*tokenizer, filename); }, std::runtime_error);
+}
+
 // Test error handling - invalid server block member error1
 TEST_F(ConfigParserTest, InvalidSeerverBlockMemberError1) {
     std::string config = R"(


### PR DESCRIPTION
## 概要 / Overview

- 1024 未満のportが指定された時にconfig errorとするように変更した

## 該当する issue

- #155 

## 変更内容

- 現状
 1 - 65535 のportを受け付ける

- 変更後
 1024 - 65535 のportを受け付ける

- 変更点
  - src/config/validator.cpp 
      if (type == LISTEN) {
        return (num >= MIN_PORT && num <= MAX_PORT);
     }
     0をMIN_PORTに変更

  - src/config/context/serverContext.cpp
     ServerContext::ServerContext(const std::string& text)
        : value_(text), listen_(0), clientMaxBodySize_(MAX_BODY_SIZE), host_("localhost") 
     hostのデフォルトを変更

  - tester の listen 80; がエラーになるので listen 8080;に変更

## 影響範囲
- xxxxxx
- xxxxxx

## その他
