### PR TITLE
[165] host, server_names work well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ SRCS	= 	src/config/tokenizer.cpp \
 	src/http/response/response_headers.cpp \
 	src/http/status.cpp \
 	src/http/virtual_server.cpp \
+	src/http/config/config_resolver.cpp \
 	src/io/base/fileDescriptor.cpp \
 	src/io/input/read/buffer.cpp \
 	src/io/input/reader/fd.cpp \

--- a/include/http/config/config_resolver.hpp
+++ b/include/http/config/config_resolver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector> // ← これが必須！
 #include "config/context/serverContext.hpp"
 #include "utils/types/error.hpp"
 #include "utils/types/option.hpp"
@@ -8,22 +9,21 @@
 namespace http {
 namespace config {
 
-// Hostヘッダー判定はserver_namesだけで行う。host_はバインド用のみ。
 class IConfigResolver {
-   public:
+public:
     virtual types::Result<const ServerContext*, error::AppError> chooseServer(
         const std::string& host) const = 0;
     virtual ~IConfigResolver() {}
 };
 
 class ConfigResolver : public IConfigResolver {
-   public:
+public:
     explicit ConfigResolver(const std::vector<ServerContext>& servers);
-
-    types::Result<const ServerContext*, error::AppError> chooseServer(
+    virtual ~ConfigResolver();
+    virtual types::Result<const ServerContext*, error::AppError> chooseServer(
         const std::string& host) const;
 
-   private:
+private:
     std::vector<ServerContext> servers_;
 };
 

--- a/include/http/config/config_resolver.hpp
+++ b/include/http/config/config_resolver.hpp
@@ -8,6 +8,7 @@
 namespace http {
 namespace config {
 
+// Hostヘッダー判定はserver_namesだけで行う。host_はバインド用のみ。
 class IConfigResolver {
    public:
     virtual types::Result<const ServerContext*, error::AppError> chooseServer(
@@ -17,29 +18,14 @@ class IConfigResolver {
 
 class ConfigResolver : public IConfigResolver {
    public:
-    explicit ConfigResolver(const std::vector<ServerContext>& servers)
-        : servers_(servers) {}
+    explicit ConfigResolver(const std::vector<ServerContext>& servers);
 
     types::Result<const ServerContext*, error::AppError> chooseServer(
-        const std::string& host) const {
-        // host: "a.test:8080" → "a.test"
-        std::size_t colon = host.find(':');
-        std::string hostname = (colon != std::string::npos) ? host.substr(0, colon) : host;
-
-        for (std::size_t i = 0; i < servers_.size(); ++i) {
-            const std::vector<std::string>& serverNames = servers_[i].getServerNames();
-            for (std::size_t j = 0; j < serverNames.size(); ++j) {
-                if (serverNames[j] == hostname) {
-                    // 一致する server_name を見つけた
-                    return types::ok(&servers_[i]);
-                }
-            }
-        }
-        return types::err(error::kBadRequest);
-    }
+        const std::string& host) const;
 
    private:
     std::vector<ServerContext> servers_;
 };
+
 }  // namespace config
 }  // namespace http

--- a/include/http/virtual_server.hpp
+++ b/include/http/virtual_server.hpp
@@ -4,6 +4,7 @@
 #include "http/handler/router/builder.hpp"
 #include "http/handler/router/router.hpp"
 
+// 仮想サーバ選択はserver_namesのみ。host_はバインド用のみ。
 class VirtualServer {
    public:
     VirtualServer(const ServerContext &serverConfig,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(webserv_lib STATIC
     http/handler/file/cgi_env.cpp
     http/handler/file/cgi_execute.cpp
     http/handler/file/cgi_parse.cpp
+	http/config/config_resolver.cpp
     http/mime.cpp
 )
 

--- a/src/http/config/config_resolver.cpp
+++ b/src/http/config/config_resolver.cpp
@@ -1,0 +1,34 @@
+#include "http/config/config_resolver.hpp"
+#include "utils/logger.hpp"
+
+namespace http {
+namespace config {
+
+// Hostヘッダー判定はserver_namesだけで行う。host_はバインド用のみ。
+ConfigResolver::ConfigResolver(const std::vector<ServerContext>& servers)
+    : servers_(servers) {}
+
+types::Result<const ServerContext*, error::AppError>
+ConfigResolver::chooseServer(const std::string& host) const {
+    // host: "webserv.test:8080" → "webserv.test"
+    std::size_t colon = host.find(':');
+    std::string hostname = (colon != std::string::npos) ? host.substr(0, colon) : host;
+
+    // server_namesのみで判定。host_は使わない。
+    for (std::size_t i = 0; i < servers_.size(); ++i) {
+        const std::vector<std::string>& serverNames = servers_[i].getServerNames();
+        for (std::size_t j = 0; j < serverNames.size(); ++j) {
+            if (serverNames[j] == hostname) {
+                return types::ok(&servers_[i]);
+            }
+        }
+    }
+    // ここで一致しなかった場合、最初のサーバーブロックを返す（default_server的挙動）
+    if (!servers_.empty()) {
+        return types::ok(&servers_[0]);
+    }
+    return types::err(error::kBadRequest);
+}
+
+}  // namespace config
+}  // namespace http

--- a/src/http/config/config_resolver.cpp
+++ b/src/http/config/config_resolver.cpp
@@ -1,20 +1,20 @@
 #include "http/config/config_resolver.hpp"
 #include "utils/logger.hpp"
+#include <vector>
 
 namespace http {
 namespace config {
 
-// Hostヘッダー判定はserver_namesだけで行う。host_はバインド用のみ。
 ConfigResolver::ConfigResolver(const std::vector<ServerContext>& servers)
     : servers_(servers) {}
 
+ConfigResolver::~ConfigResolver() {}
+
 types::Result<const ServerContext*, error::AppError>
 ConfigResolver::chooseServer(const std::string& host) const {
-    // host: "webserv.test:8080" → "webserv.test"
     std::size_t colon = host.find(':');
     std::string hostname = (colon != std::string::npos) ? host.substr(0, colon) : host;
 
-    // server_namesのみで判定。host_は使わない。
     for (std::size_t i = 0; i < servers_.size(); ++i) {
         const std::vector<std::string>& serverNames = servers_[i].getServerNames();
         for (std::size_t j = 0; j < serverNames.size(); ++j) {
@@ -23,7 +23,6 @@ ConfigResolver::chooseServer(const std::string& host) const {
             }
         }
     }
-    // ここで一致しなかった場合、最初のサーバーブロックを返す（default_server的挙動）
     if (!servers_.empty()) {
         return types::ok(&servers_[0]);
     }

--- a/src/http/virtual_server.cpp
+++ b/src/http/virtual_server.cpp
@@ -14,12 +14,14 @@
 #include "utils/logger.hpp"
 
 // ---- Hostによる仮想サーバ選択 ----
+// matchesHostはhost_は使わず、server_namesのみで判定
 bool VirtualServer::matchesHost(const std::string &host) const {
     std::string hostOnly = host;
     std::string::size_type colonPos = host.find(':');
     if (colonPos != std::string::npos) {
         hostOnly = host.substr(0, colonPos);
     }
+    // server_namesのみ
     const std::vector<std::string> &names = serverConfig_.getServerNames();
     for (std::vector<std::string>::const_iterator it = names.begin(); it != names.end(); ++it) {
         if (*it == hostOnly) {
@@ -38,7 +40,6 @@ VirtualServer* VirtualServer::findByHost(const std::vector<VirtualServer*>& serv
     return NULL;
 }
 
-// ---- 既存の処理 ----
 VirtualServer::VirtualServer(const ServerContext &serverConfig,
                              const std::string &bindAddress)
     : serverConfig_(serverConfig), bindAddress_(bindAddress), router_(NULL) {


### PR DESCRIPTION
## 概要 / Overview
以下の設定で、
```
server {
  listen 8080;
  host localhost;
  server_names www.webserv.com webserv.test;

  error_page 404 www/html/404.html;
  # error_page 405 www/html/405.html;
  error_page 500 /500.html;
  client_max_body_size 1000000;

  location / {
    allow_method GET POST;
    root ./www/html;
    index index.html;
  }

  location /upload {
    allow_method GET POST DELETE;
    root ./www/user_uploads;
    enable_upload ON;
    autoindex ON;
  }

  location /download {
    allow_method GET POST DELETE;
    root ./www/user_downloads;
    enable_upload ON;
    autoindex ON;
  }

  location /old {
    redirect /upload;
    allow_method GET;
  }
}
```

以下のレスポンスが返えるように修正
```
~/webserv [165-bug-200-returns-404 ⛈]
🌕 % curl -v http://localhost:8080/index.html
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* connect to ::1 port 8080 from ::1 port 60980 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Established connection to localhost (127.0.0.1 port 8080) from 127.0.0.1 port 38656
* using HTTP/1.x
> GET /index.html HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.16.0
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< connection: keep-alive
< content-length: 29
< content-type: text/html; charset=UTF-8
<
<html><body>OK</body></html>
* Connection #0 to host localhost:8080 left intact
~/webserv [165-bug-200-returns-404 🌤]
🌕 % curl --resolve webserv.test:8080:127.0.0.1 http://webserv.test:8080/
<html><body>OK</body></html>
~/webserv [165-bug-200-returns-404 🌤]
🌕 % curl --resolve www.webserv.com:8080:127.0.0.1 http://www.webserv.com:8080/
<html><body>OK</body></html>
~/webserv [165-bug-200-returns-404 🌤]
🌕 %
```
## 該当する issue

- #165 

## 変更内容

- 現状

- 変更後

- 変更点
  - xxxxxx
  - xxxxxx
  - xxxxxx

## 影響範囲
- xxxxxx
- xxxxxx

## その他
