### PR TITLE
170 cgt path and validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ SRCS	= 	src/config/tokenizer.cpp \
 	src/http/handler/file/cgi_target.cpp \
 	src/http/handler/file/cgi.cpp \
 	src/http/handler/file/upload.cpp \
+	src/http/handler/file/fileOrCgi.cpp \
 	src/http/handler/router/builder.cpp \
 	src/http/handler/router/internal.cpp \
 	src/http/handler/router/middleware/chain.cpp \

--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -32,4 +32,14 @@ server {
     redirect /upload;
     allow_method GET;
   }
+
+  location /shop {
+    root ./www/shop;
+    index index.html;
+  }
+
+  location .py {
+    root ./www/cgi-bin;
+    is_cgi ON;
+  }
 }

--- a/include/config/validator.hpp
+++ b/include/config/validator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config/context/locationContext.hpp"
+
 class Token;
 
 #include <sys/stat.h>
@@ -23,4 +25,5 @@ bool isValidIndexFile(const std::string& indexFile);
 std::string dirOf(const std::string& path);
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 bool isValidRoot(const std::string& root, const std::string& confPath);
+bool isCgiValid(const LocationContext& location);
 }  // namespace Validator

--- a/include/http/handler/file/fileOrCgi.hpp
+++ b/include/http/handler/file/fileOrCgi.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "config/context/documentRootConfig.hpp"
+#include "http/handler/handler.hpp"
+#include "http/handler/file/static.hpp"
+#include "http/handler/file/cgi.hpp"
+#include "utils/string.hpp"
+
+namespace http {
+
+class FileOrCgiHandler : public IHandler {
+public:
+    explicit FileOrCgiHandler(const DocumentRootConfig& docRoot);
+
+    virtual Either<IAction*, Response> serve(const Request& req);
+
+private:
+    bool isCgiTarget_(const std::string& full) const;
+
+    DocumentRootConfig      docRoot_;
+    StaticFileHandler       static_;
+    CgiHandler              cgi_;
+};
+} // namespace http

--- a/include/http/handler/router/builder.hpp
+++ b/include/http/handler/router/builder.hpp
@@ -17,6 +17,8 @@ namespace http {
 
         RouterBuilder& route(HttpMethod httpMethod, const std::string& routePath, IHandler* routeHandler);
         RouterBuilder& route(const std::vector<HttpMethod>& httpMethodList, const std::string& routePath, IHandler* routeHandler);
+        RouterBuilder& routeForExtension(HttpMethod method, const std::string& path,
+                                                    const std::string& ext, IHandler* handler);
         RouterBuilder& middleware(IMiddleware* middlewareInstance);
 
         Router* build();

--- a/include/http/handler/router/registry.hpp
+++ b/include/http/handler/router/registry.hpp
@@ -19,8 +19,13 @@ namespace http {
 
         void addRoute(HttpMethod method, const std::string& path, IHandler* handler);
         void addRoute(const std::vector<HttpMethod>& methods, const std::string& path, IHandler* handler);
+        // 拡張子用の登録（例: ".py"）
+        void addRouteForExtension(HttpMethod method, const std::string& path, const std::string& ext, IHandler* handler);
 
         IHandler* findHandler(HttpMethod method, const std::string& path) const;
+        // 既存の findHandler に “拡張子考慮版” を足す
+        IHandler* findHandlerFor(HttpMethod method, const std::string& path, const std::string& ext /* ".py" or "" */) const;
+
         std::vector<HttpMethod> getAllowedMethods(const std::string& path) const;
 
         const HandlerMap& getHandlers() const;
@@ -29,6 +34,12 @@ namespace http {
 
     private:
         HandlerMap handlers_;
+
+        // ★追加: path -> (ext -> (method -> handler))
+        typedef std::map<std::string, MethodHandlerMap> ExtMethodMap;
+        typedef std::map<Path, ExtMethodMap>            ExtHandlerMap;
+        ExtHandlerMap extHandlers_;
+
         mutable Matcher<Path>* pathMatcher_;
         mutable bool matcherDirty_;
 

--- a/include/utils/path.hpp
+++ b/include/utils/path.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include "utils/string.hpp"
 
 namespace utils {
 namespace path {
@@ -117,6 +118,35 @@ inline bool isPathUnderRoot(const std::string& root,
     }
     return path.compare(0, root.size(), root) == 0 &&
            (path.size() == root.size() || path[root.size()] == '/');
+}
+
+inline std::string stripQuery(const std::string& target) {
+    const std::string::size_type pos = target.find('?');
+    if (pos == std::string::npos) {
+        return target;
+    } else {
+        return target.substr(0, pos);
+    }
+
+}
+
+// "/a/b.py" -> ".py", "/a/b" -> "", "/.htaccess" -> ""（隠しファイル扱い）
+inline std::string getExtension(const std::string& path) {
+    std::string newPath = stripQuery(path);
+    const std::string::size_type slash = newPath.find_last_of('/');
+    const std::string::size_type dot = newPath.find_last_of('.');
+    if (dot == std::string::npos) {
+        return "";
+    }
+    if (slash != std::string::npos && dot < slash) {
+        return "";
+    }
+    // 先頭ドットだけの隠しファイルは拡張子なしとみなす
+    if (dot == 0) {
+        return "";
+    }
+    std::string ext = newPath.substr(dot);
+    return utils::toLower(ext);
 }
 
 }  // namespace path

--- a/src/config/parser.cpp
+++ b/src/config/parser.cpp
@@ -202,6 +202,10 @@ void ConfigParser::addLocation_(ServerContext& server, size_t& index) {
         } else if (type == BRACE) {
             updateDepth(tokens_[index], lineNum);
             if (this->depth_ == 1) {
+                if (!Validator::isCgiValid(location)) {
+                                throwErr(text, ": cgi setting error: line",
+                     lineNum);
+                }
                 setDefaultMethod_(location);
                 server.getLocation().push_back(location);
                 break;

--- a/src/config/validator.cpp
+++ b/src/config/validator.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 
 #include "config/token.hpp"
+#include "config/context/documentRootConfig.hpp"
 
 bool Validator::number(const std::string& number, int type) {
     for (size_t i = 0; i < number.size(); ++i) {
@@ -62,4 +63,26 @@ bool Validator::isValidRoot(const std::string& root,
 
     return stat(path.c_str(), &sta) == 0 && S_ISDIR(sta.st_mode) &&
            access(path.c_str(), R_OK | X_OK) == 0;
+}
+
+bool Validator::isCgiValid(const LocationContext& location) {
+    std::string text = location.getPath();
+    OnOff cgiExtension = location.getDocumentRootConfig().getCgiExtensions();
+
+    if (text.empty()) {
+        return false;
+    }
+    if (text[0] != '.') {
+        return true;
+    }
+    if (text.size() != 3) {
+        return false;
+    }
+    if (text == ".py" && cgiExtension == OFF) {
+        return false;
+    }
+    if (text != ".py" && cgiExtension == ON) {
+        return false;
+    }
+    return true;
 }

--- a/src/http/handler/file/cgi_target.cpp
+++ b/src/http/handler/file/cgi_target.cpp
@@ -25,6 +25,29 @@ std::string fsToVirtual(const std::string& root, const std::string& fileSystem);
 }  // namespace
 
 // 本体
+// bool CgiHandler::isCgiTarget(const Request& req, std::string* scriptPath,
+//                              std::string* pathInfo) const {
+//     if (!initCheck(req, scriptPath, pathInfo)) {
+//         return false;
+//     }
+
+//     const std::string& root = docRootConfig_.getRoot();
+//     std::string rel = req.getPath();
+//     if (!rel.empty() && rel[0] == '/') {
+//         rel.erase(0, 1);
+//     }
+
+//     const std::string full = utils::joinPath(root, rel);
+//     LOG_DEBUG("CgiHandler::isCgiTarget : CGI joinPath information" + full);
+//     const std::string norm = utils::normalizePath(full);
+
+//     // if (!checkIsUnderRoot(root, norm)) {
+//     //     return false;
+//     // }
+//     return splitScriptAndPathInfo(root, norm, scriptPath, pathInfo);
+// }
+
+
 bool CgiHandler::isCgiTarget(const Request& req, std::string* scriptPath,
                              std::string* pathInfo) const {
     if (!initCheck(req, scriptPath, pathInfo)) {
@@ -38,13 +61,26 @@ bool CgiHandler::isCgiTarget(const Request& req, std::string* scriptPath,
     }
 
     const std::string full = utils::joinPath(root, rel);
-    LOG_DEBUG("CgiHandler::isCgiTarget : CGI joinPath information" + full);
-    const std::string norm = utils::normalizePath(full);
 
-    // if (!checkIsUnderRoot(root, norm)) {
-    //     return false;
-    // }
-    return splitScriptAndPathInfo(root, norm, scriptPath, pathInfo);
+    const OnOff& cgiExtension = docRootConfig_.getCgiExtensions();
+    if (cgiExtension == OFF) {
+        return false;
+    }
+    if (full.size() < 3) {
+        return false;
+    }
+    const std::string lower = utils::toLower(full);
+    if (lower.compare(lower.size() - 3, 3, ".py") != 0) {
+        return false;
+    }
+    struct stat st;
+    if (stat(full.c_str(), &st) != 0 || !S_ISREG(st.st_mode)) {
+        return false;
+    }
+    if (access(full.c_str(), X_OK) != 0) {
+        return false;
+    }
+    return true;
 }
 
 namespace {

--- a/src/http/handler/file/fileOrCgi.cpp
+++ b/src/http/handler/file/fileOrCgi.cpp
@@ -1,0 +1,50 @@
+#warning "fileOrCgi.cpp is compiled"
+#include "http/handler/file/fileOrCgi.hpp"
+
+#include "http/request/request.hpp"
+#include "utils/logger.hpp"
+#include <unistd.h>
+
+namespace http {
+
+FileOrCgiHandler::FileOrCgiHandler(const DocumentRootConfig& docRoot)
+         : docRoot_(docRoot), static_(docRoot), cgi_(docRoot) {
+            LOG_INFO("FileOrCgiHandler ctor: root=" + docRoot_.getRoot());
+         }
+
+Either<IAction*, Response> FileOrCgiHandler::serve(const Request& req) {
+    const std::string& target = req.getRequestTarget();     // 例: "/happy.py"
+    const std::string full    = docRoot_.getRoot() + target; // 例: "./www/cgi-bin/happy.py"
+    LOG_INFO("FileOrCgiHandler invoked: target=" + target + " full=" + full);
+
+    if (isCgiTarget_(full)) { 
+        LOG_INFO("CGI selected");
+        return cgi_.serve(req); 
+    }
+    LOG_INFO("Static selected (within FileOrCgiHandler)");
+    return static_.serve(req);
+}
+
+bool FileOrCgiHandler::isCgiTarget_(const std::string& full) const {
+    const OnOff& cgiExtension = docRoot_.getCgiExtensions();
+    if (cgiExtension == OFF) {
+        return false;
+    }
+    if (full.size() < 3) {
+        return false;
+    }
+    const std::string lower = utils::toLower(full);
+    if (lower.compare(lower.size() - 3, 3, ".py") != 0) {
+        return false;
+    }
+    struct stat st;
+    if (stat(full.c_str(), &st) != 0 || !S_ISREG(st.st_mode)) {
+        return false;
+    }
+    if (access(full.c_str(), X_OK) != 0) {
+        return false;
+    }
+    return true;
+}
+
+} // namespace http

--- a/src/http/handler/router/builder.cpp
+++ b/src/http/handler/router/builder.cpp
@@ -33,6 +33,13 @@ namespace http {
         return *this;
     }
 
+    RouterBuilder& RouterBuilder::routeForExtension(HttpMethod method, const std::string& path,
+                                                    const std::string& ext, IHandler* handler) {
+        std::cerr << "routeForExtension" << std::endl;
+        routerInstance_->routeRegistry_->addRouteForExtension(method, path, ext, handler);
+        return *this;
+    }
+
     RouterBuilder& RouterBuilder::middleware(IMiddleware* middlewareInstance) {
         if (isBuilt_) {
             LOG_ERROR("RouterBuilder: Cannot add middleware after build()");

--- a/src/http/handler/router/internal.cpp
+++ b/src/http/handler/router/internal.cpp
@@ -4,6 +4,7 @@
 #include "http/response/builder.hpp"
 #include "http/method.hpp" // isMethodImplementedを使う
 #include "utils/logger.hpp"
+#include "utils/path.hpp"
 
 namespace http {
     InternalRouter::InternalRouter(const RouteRegistry& registry) 
@@ -14,15 +15,21 @@ namespace http {
         if (!isMethodImplemented(req.getMethod())) {
             return Right(ResponseBuilder().status(kStatusNotImplemented).build());
         }
+        // パスのみでマッチ
+        const std::string& target = req.getRequestTarget();
+        const std::string::size_type query = target.find('?');
+        const std::string pathOnly = (query == std::string::npos) ? target : target.substr(0, query);
 
-        const types::Option<std::string> matchResult = registry_.matchPath(req.getRequestTarget());
+        const types::Option<std::string> matchResult = registry_.matchPath(pathOnly);
         if (matchResult.isNone()) {
             return Right(ResponseBuilder().status(kStatusNotFound).build());
         }
 
-        const std::string& matchedPath = matchResult.unwrap();
+        const std::string& matchedPath = matchResult.unwrap(); // "/" や "/upload" や ".py"
         Logger& log = Logger::instance();
         LOG_INFO("MatchedPath information:" + matchedPath + "");
+
+        // IHandler* handler = registry_.findHandler(req.getMethod(), matchedPath);
         IHandler* handler = registry_.findHandler(req.getMethod(), matchedPath);
 
         if (!handler) {

--- a/src/http/handler/router/registry.cpp
+++ b/src/http/handler/router/registry.cpp
@@ -1,4 +1,5 @@
 #include "http/handler/router/registry.hpp"
+#include "utils/types/option.hpp"
 #include <set>
 
 namespace http {
@@ -30,28 +31,96 @@ namespace http {
             this->addRoute(*it, path, handler);
         }
     }
-   
+    
+    // この path で、拡張子が ext のとき、method は handler を使う
+    // 例: ("/", ".py", GET) -> CgiHandler* の設定で、「/hello.py に GET が来たら CGI」を選べるようになる
+    void RouteRegistry::addRouteForExtension(HttpMethod method, const std::string& path, const std::string& ext, IHandler* handler) {
+        // 例: path="/", ext=".py"
+        std::cerr << "addRouteForExtension" << std::endl;
+        IHandler*& slot = extHandlers_[path][ext][method];
+        if (slot) {
+            delete slot;
+        }
+        slot = handler;
+        invalidateMatcher();
+    }
+
+    // 同じ path に対しても、拡張子（例: .py）で優先ハンドラを切り替える
+    // データ構造（イメージ）
+    // handlers_      : path -> (method -> handler)            既存：拡張子に関係ないデフォルト
+    // extHandlers_   : path -> (ext -> (method -> handler))   追加
+    IHandler* RouteRegistry::findHandlerFor(HttpMethod method, const std::string& path, const std::string& ext /* ".py" or "" */) const {
+        // 拡張子優先
+        if (!ext.empty()) {
+            ExtHandlerMap::const_iterator pit = extHandlers_.find(path);
+            if (pit != extHandlers_.end()) {
+                ExtMethodMap::const_iterator eit = pit->second.find(ext);
+                if (eit != pit->second.end()) {
+                    MethodHandlerMap::const_iterator mit = eit->second.find(method);
+                    if (mit != eit->second.end()) {
+                        return mit->second;
+                    }
+                }
+            }
+        }
+        // なければ従来どおり
+        return findHandler(method, path);
+    }
+
     void RouteRegistry::invalidateMatcher() const {
         matcherDirty_ = true;
     }
 
+    // マッチャには “/ で始まるキーのみ” を入れる
     void RouteRegistry::ensureMatcherUpdated() const {
         if (matcherDirty_) {
             delete pathMatcher_;
+            pathMatcher_ = NULL;
             
             std::map<Path, Path> paths;
             for (HandlerMap::const_iterator it = handlers_.begin(); it != handlers_.end(); ++it) {
-                paths[it->first] = it->first;
+                const std::string& key = it->first;
+                if (!key.empty() && key[0] == '/') {
+                    paths[key] = key;
+                }
+                
             }
             pathMatcher_ = new Matcher<Path>(paths);
             matcherDirty_ = false;
         }
     }
 
+    // 前方一致 → ダメなら拡張子末尾一致
     types::Option<RouteRegistry::Path> RouteRegistry::matchPath(const std::string& requestPath) const {
         ensureMatcherUpdated();
-        return pathMatcher_->match(requestPath);
+    
+        // クエリを落とした「パスのみ」
+        const std::string::size_type query = requestPath.find('?');
+        const std::string pathOnly = (query == std::string::npos) ? requestPath : requestPath.substr(0, query);
+        // 通常の前方一致
+        types::Option<Path> prefix = pathMatcher_->match(requestPath);
+        // ".ext" キーで末尾一致（最長を優先：.tar.gz > .gz）
+        std::string bestKey;
+        std::size_t bestLen = 0;
+        for (HandlerMap::const_iterator it = handlers_.begin(); it != handlers_.end(); ++it) {
+            const std::string& key = it->first;
+            if (key.empty() || key[0] != '.') continue;  // ドットで始まるキーだけ対象
+            if (pathOnly.size() >= key.size() &&
+                pathOnly.compare(pathOnly.size() - key.size(), key.size(), key) == 0) {
+                if (key.size() > bestLen) { bestKey = key; bestLen = key.size(); }
+            }
+        }
+        if (bestLen > 0) {
+            return types::some(bestKey);
+        }
+        if (!prefix.isNone()) {
+            return prefix;
+        }
+        // どれにも合わなければ None
+        return types::none<Path>();
+        // return pathMatcher_->match(requestPath);
     }
+
     IHandler* RouteRegistry::findHandler(HttpMethod method, const std::string& path) const {
         const HandlerMap::const_iterator pathIt = handlers_.find(path);
         if (pathIt != handlers_.end()) {

--- a/src/http/handler/router/registry.cpp
+++ b/src/http/handler/router/registry.cpp
@@ -36,7 +36,6 @@ namespace http {
     // 例: ("/", ".py", GET) -> CgiHandler* の設定で、「/hello.py に GET が来たら CGI」を選べるようになる
     void RouteRegistry::addRouteForExtension(HttpMethod method, const std::string& path, const std::string& ext, IHandler* handler) {
         // 例: path="/", ext=".py"
-        std::cerr << "addRouteForExtension" << std::endl;
         IHandler*& slot = extHandlers_[path][ext][method];
         if (slot) {
             delete slot;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv) {
         try {
                 const Config config(confFile);
                 LOG_INFO("Configuration loaded successfully");
-                // config.printParser();
+                config.printParser();
                 Server server(config.getParser().getServer());
                 server.init();
                 LOG_INFO("Server initialized");

--- a/www/shop/test.html
+++ b/www/shop/test.html
@@ -1,0 +1,1 @@
+test.html


### PR DESCRIPTION
## 概要 / Overview

- configファイル
　　".py"と is_cgi ON; が両方揃わない時はエラーとして弾く
- CgiHandlerを呼べるようにする

## 該当する issue

- #170 

## 変更内容
１．configの変更
　config/parser.cpp/addLocation()に以下を追加しました

```
　                if (!Validator::isCgiValid(location)) {
                                throwErr(text, ": cgi setting error: line",
                     lineNum);
                }
```

config/validator.cpp/にisCgiValid()を追加しました

```
bool Validator::isCgiValid(const LocationContext& location) {
    std::string text = location.getPath();
    OnOff cgiExtension = location.getDocumentRootConfig().getCgiExtensions();

    if (text.empty()) {
        return false;
    }
    if (text[0] != '.') {
        return true;
    }
    if (text.size() != 3) {
        return false;
    }
    if (text == ".py" && cgiExtension == OFF) {
        return false;
    }
    if (text != ".py" && cgiExtension == ON) {
        return false;
    }
    return true;
}
```

２．http/handler/router/internal.cpp/serve()を変更しました

```
    Either<IAction*, Response> InternalRouter::serve(const Request& req) {
        // GET/POST/DELETE以外は501
        if (!isMethodImplemented(req.getMethod())) {
            return Right(ResponseBuilder().status(kStatusNotImplemented).build());
        }
        // パスのみでマッチ
        const std::string& target = req.getRequestTarget();
        const std::string::size_type query = target.find('?');
        const std::string pathOnly = (query == std::string::npos) ? target : target.substr(0, query);

        const types::Option<std::string> matchResult = registry_.matchPath(pathOnly);
        if (matchResult.isNone()) {
            return Right(ResponseBuilder().status(kStatusNotFound).build());
        }

        const std::string& matchedPath = matchResult.unwrap(); // "/" や "/upload" や ".py"
        Logger& log = Logger::instance();
        LOG_INFO("MatchedPath information:" + matchedPath + "");

        // IHandler* handler = registry_.findHandler(req.getMethod(), matchedPath);
        IHandler* handler = registry_.findHandler(req.getMethod(), matchedPath);

        if (!handler) {
            LOG_WARN("handler is not registered. matched path or method is not allowed");
            const std::vector<HttpMethod> allowedMethods = registry_.getAllowedMethods(matchedPath);
            if (!allowedMethods.empty()) {
                return Right(ResponseBuilder().status(kStatusMethodNotAllowed).build());
            }
            return Right(ResponseBuilder().status(kStatusNotFound).build());
        }
        return handler->serve(req);
    }
```
matchPathの引数を変更しました。req.getRequestTarget()から？以降を取り除いています。


３．http/handler/router/registry.cppを変更しました
・addRouteForExtension()を作成しました
```
    // この path で、拡張子が ext のとき、method は handler を使う
    // 例: ("/", ".py", GET) -> CgiHandler* の設定で、「/hello.py に GET が来たら CGI」を選べるようになる
    void RouteRegistry::addRouteForExtension(HttpMethod method, const std::string& path, const std::string& ext, IHandler* handler) {
        // 例: path="/", ext=".py"
        IHandler*& slot = extHandlers_[path][ext][method];
        if (slot) {
            delete slot;
        }
        slot = handler;
        invalidateMatcher();
    }
```

・findHandlerFor()は作成しましたが結局使っていません。後で消そうと思います。
・ensureMatcherUpdated()は以下を加えました

```
                const std::string& key = it->first;
                if (!key.empty() && key[0] == '/') {
                    paths[key] = key;
                }
```

・matchPath()は拡張子の末尾一致を加えました

```
    // 前方一致 → ダメなら拡張子末尾一致
    types::Option<RouteRegistry::Path> RouteRegistry::matchPath(const std::string& requestPath) const {
        ensureMatcherUpdated();
    
        // クエリを落とした「パスのみ」
        const std::string::size_type query = requestPath.find('?');
        const std::string pathOnly = (query == std::string::npos) ? requestPath : requestPath.substr(0, query);
        // 通常の前方一致
        types::Option<Path> prefix = pathMatcher_->match(requestPath);
        // ".ext" キーで末尾一致（最長を優先：.tar.gz > .gz）
        std::string bestKey;
        std::size_t bestLen = 0;
        for (HandlerMap::const_iterator it = handlers_.begin(); it != handlers_.end(); ++it) {
            const std::string& key = it->first;
            if (key.empty() || key[0] != '.') continue;  // ドットで始まるキーだけ対象
            if (pathOnly.size() >= key.size() &&
                pathOnly.compare(pathOnly.size() - key.size(), key.size(), key) == 0) {
                if (key.size() > bestLen) { bestKey = key; bestLen = key.size(); }
            }
        }
        if (bestLen > 0) {
            return types::some(bestKey);
        }
        if (!prefix.isNone()) {
            return prefix;
        }
        // どれにも合わなければ None
        return types::none<Path>();
        // return pathMatcher_->match(requestPath);
    }
```
    
４．http/virtual_server.cppのsetupRouter()を変更しました

```
        // 拡張子ロケーション（例: ".py"）
        if (!path.empty() && path[0] == '.') {
            if (allowed[GET] == ON) {
                routerBuilder.route(http::kMethodGet, path, new http::CgiHandler(docRoot));
            }
            if (allowed[POST] == ON) {
                routerBuilder.route(http::kMethodPost, path, new http::CgiHandler(docRoot));
            }
            continue;
        }

        // 通常のパスロケーション（"/", "/upload", ...）
        if (allowed[GET] == ON) {
            routerBuilder.route(http::kMethodGet, path,
                                new http::StaticFileHandler(docRoot));
        }
        if (allowed[POST] == ON) {
            routerBuilder.route(http::kMethodPost, path,
                                new http::UploadFileHandler(docRoot));
        }
        if (allowed[DELETE] == ON) {
            routerBuilder.route(http::kMethodDelete, path,
                                new http::DeleteFileHandler(docRoot, path));
        }
```

CgiHandlerを呼ぶ条件を変更しました


５．utils/path.hppに関数を２つ追加しました。後で堅牢化する時に使う予定です。

```
inline std::string stripQuery(const std::string& target) {
    const std::string::size_type pos = target.find('?');
    if (pos == std::string::npos) {
        return target;
    } else {
        return target.substr(0, pos);
    }

}

// "/a/b.py" -> ".py", "/a/b" -> "", "/.htaccess" -> ""（隠しファイル扱い）
inline std::string getExtension(const std::string& path) {
    std::string newPath = stripQuery(path);
    const std::string::size_type slash = newPath.find_last_of('/');
    const std::string::size_type dot = newPath.find_last_of('.');
    if (dot == std::string::npos) {
        return "";
    }
    if (slash != std::string::npos && dot < slash) {
        return "";
    }
    // 先頭ドットだけの隠しファイルは拡張子なしとみなす
    if (dot == 0) {
        return "";
    }
    std::string ext = newPath.substr(dot);
    return utils::toLower(ext);
}
```

６．実行結果

```
[2025/10/10 00:57:50+0900] [INFO] <-- GET /hello.py
[2025/10/10 00:57:50+0900] [INFO] MatchedPath information:.py
[2025/10/10 00:57:50+0900] [INFO] cgiHandler serve: function invoked
[2025/10/10 00:57:50+0900] [DEBUG] CgiHandler::isCgiTarget : CGI joinPath information./www/cgi-bin/hello.py
[2025/10/10 00:57:50+0900] [WARN] cgiHandler serve: cannot find CgiTarget
[2025/10/10 00:57:50+0900] [INFO] --> GET /hello.py 404
```

CgiHandlerを呼べるようになりました。404に関してはcgi.cpp/serveInternal()の処理の修正が必要みたいです。conflictが起こりそうなのでこの状態で渡したいと思います。
以下chatGPTのコメントです

```
CgiHandler 側の最小修正（コードで吸収したい場合）

今の join が固定で "./www/cgi-bin" を付けているなら、設定から渡されたルートを使うようにします。
また、クエリを落として basename を取るのも忘れずに。
```
```
Response CgiHandler::serve(const Request& req) {
    const std::string target = req.getRequestTarget();
    const std::string::size_type q = target.find('?');
    const std::string pathOnly = (q == std::string::npos) ? target : target.substr(0, q);

    // /dir/hello.py → hello.py
    const std::string::size_type slash = pathOnly.rfind('/');
    const std::string filename = (slash == std::string::npos) ? pathOnly : pathOnly.substr(slash + 1);

    // 設定の root（または cgiRoot）が優先
    const std::string base = documentRootConfig_.getRoot();           // 例: "./www/cgi-bin"
    const std::string script = base + "/" + filename;

    struct stat st;
    if (::stat(script.c_str(), &st) != 0) {
        LOG_WARN(std::string("CgiHandler: stat failed: ") + script + " errno=" + utils::toString(errno));
        return ResponseBuilder().status(kStatusNotFound).build();
    }
    if (!S_ISREG(st.st_mode)) {
        return ResponseBuilder().status(kStatusForbidden).build();
    }

    // 以降、execve の準備（shebang あり前提）
    // ...
}
```
```
もし DocumentRootConfig に getCgiRoot() 的な別項目があるなら、base はそちらを優先し、未設定なら getRoot() を使う、という順にすると柔軟です。
```

ひとまずお渡しします。cgiHandlerを呼んでしばらくするとセグフォが起きます。これについては別のissueで対応したいと思います。



- 現状

- 変更後

- 変更点
  - xxxxxx
  - xxxxxx
  - xxxxxx

## 影響範囲
- xxxxxx
- xxxxxx

## その他
