### PR TITLE
173 bugfix readwrite

### DIFF
--- a/include/action/cgi_context.hpp
+++ b/include/action/cgi_context.hpp
@@ -55,7 +55,7 @@ public:
     int getFdOut() const;
     void setFdIn(int fd);
     void setFdOut(int fd);
-    const pid_t getPid() const;
+    pid_t getPid() const;
     size_t getWritten() const;
     void setWritten(size_t writeSize);
     std::string getRawOut();

--- a/include/action/cgi_context.hpp
+++ b/include/action/cgi_context.hpp
@@ -45,7 +45,7 @@ public:
     void setProc(pid_t pid, int fd_in, int fd_out, time_t now);
     void setStdinBody(const std::vector<char>* body);
     const std::vector<char>* getStdinBody() const; 
-    time_t startTime() const;
+    time_t getLastRecv() const;
     void   terminateChild(); // SIGTERM -> SIGKILL は Server 側でやるなら呼び出しのみ
 
     // 付帯情報
@@ -60,6 +60,8 @@ public:
     void setWritten(size_t writeSize);
     std::string getRawOut();
     void setRawOut(std::string raw);
+    void setLastRecv(time_t time);
+    static const time_t kCGITimeoutThresholdSec = 15;
 
 private:
     CgiContext(const CgiContext&);

--- a/include/io/handler/ClientHandler.hpp
+++ b/include/io/handler/ClientHandler.hpp
@@ -16,7 +16,7 @@ private:
     void handlePeerHalfClose(Connection& c);
     void maybeDispatch(Connection& c);
     void handleReadError(Connection& c, const error::AppError& err);
-    void handleWriteError(Connection& c, int sys_errno);
+    // void handleWriteError(Connection& c, int sys_errno);
     void failAndClose(Connection& c, const error::AppError& err);
     static http::HttpStatusCode mapParseErrorToHttpStatus(error::AppError err);
 };

--- a/include/io/handler/ClientHandler.hpp
+++ b/include/io/handler/ClientHandler.hpp
@@ -15,7 +15,7 @@ private:
     void handleHangup(Connection& c);
     void handlePeerHalfClose(Connection& c);
     void maybeDispatch(Connection& c);
-    void handleReadError(Connection& c, const error::AppError& err);
+    // void handleReadError(Connection& c, const error::AppError& err);
     // void handleWriteError(Connection& c, int sys_errno);
     void failAndClose(Connection& c, const error::AppError& err);
     static http::HttpStatusCode mapParseErrorToHttpStatus(error::AppError err);

--- a/include/io/input/read/buffer.hpp
+++ b/include/io/input/read/buffer.hpp
@@ -13,7 +13,7 @@ public:
 
     types::Result<types::Option<std::string>, error::AppError>
     consumeUntil(const std::string &delimiter);
-
+    void clear();
     std::string consume(std::size_t nbyte);
 
     typedef types::Result<std::size_t, error::AppError> LoadResult;

--- a/include/server/Server.hpp
+++ b/include/server/Server.hpp
@@ -42,7 +42,6 @@ class Server {
         void armOutOnly(int fd);
         void armInOut(int fd);
         RequestDispatcher* getDispatcher() const;
-        static const time_t kTimeoutThresholdSec = 30;
         static const time_t kCGITimeoutThresholdSec = 15;
     private:
         std::vector<ServerContext> serverCtxs_;

--- a/include/server/connection/Connection.hpp
+++ b/include/server/connection/Connection.hpp
@@ -19,7 +19,6 @@ private:
     http::RequestReader requestReader_;
     Connection(const Connection&);
     Connection& operator=(const Connection&);
-    static const std::time_t kTimeoutThresholdSec = 60;
     std::deque<http::Request> pending_;
     bool frontDispatched_;
     bool closeAfterWrite_;
@@ -30,7 +29,6 @@ private:
 
 
 public:
-    // Connection (int fd, const ISocketAddr& peerAddr);
     Connection(int fd, const ISocketAddr& peerAddr,
                        http::config::IConfigResolver& resolver);
 
@@ -51,7 +49,7 @@ public:
     void popFront();
     http::Request& front();
     void pushCreatedReq(http::Request req);
-    http::RequestReader& getRequestReader();   // 非const版（HandlerでreadRequestするため）
+    http::RequestReader& getRequestReader();
     bool isPeerHalfClosed() const;
     void onPeerHalfClose();
     bool shouldCloseAfterWrite() const;
@@ -66,4 +64,5 @@ public:
     CgiContext* getCgi() const;
     bool isCgiActive() const;
     void clearCgi();
+    static const std::time_t kTimeoutThresholdSec = 10;
 };

--- a/include/server/dispatcher/RequestDispatcher.hpp
+++ b/include/server/dispatcher/RequestDispatcher.hpp
@@ -14,9 +14,6 @@ public:
     // ClientHandler から呼ばれる単一ステップ
     DispatchResult step(Connection& c);
 
-    // CGI stdout/ stdin 用のモック（今は形だけ）
-    DispatchResult onCgiStdout(Connection& c);
-    DispatchResult onCgiStdin(Connection& c);
     DispatchResult emitError(Connection& c, http::HttpStatusCode status, const std::string& plain);
     DispatchResult finalizeCgi(Connection& c);
 

--- a/src/action/cgi_action.cpp
+++ b/src/action/cgi_action.cpp
@@ -3,6 +3,6 @@
 CgiActionPrepared::CgiActionPrepared(const PreparedCgi& preparedCgi) : preparedCgi_(preparedCgi){}
 
 void CgiActionPrepared::execute(ActionContext &ctx) {
-
+    (void)ctx;
 }
 

--- a/src/action/cgi_context.cpp
+++ b/src/action/cgi_context.cpp
@@ -37,9 +37,14 @@ const std::vector<char>* CgiContext::getStdinBody() const{
     return stdinBody_;
 }
 
-time_t CgiContext::startTime() const {
+time_t CgiContext::getLastRecv() const {
     return t0_;
 }
+
+void CgiContext::setLastRecv(time_t time){
+    t0_ = time;
+}
+
 
 void CgiContext::terminateChild() {
     // Escalation（SIGTERM->SIGKILL）は Server 側ポリシーで実施する前提。

--- a/src/action/cgi_context.cpp
+++ b/src/action/cgi_context.cpp
@@ -70,7 +70,7 @@ void CgiContext::setFdOut(int fd) {
     fd_out_ = fd;
 }
 
-const pid_t CgiContext::getPid() const {
+pid_t CgiContext::getPid() const {
     return pid_;
 }
 

--- a/src/http/handler/file/cgi.cpp
+++ b/src/http/handler/file/cgi.cpp
@@ -16,7 +16,6 @@ CgiHandler::CgiHandler(const DocumentRootConfig& docRootConfig)
 Either<IAction*, Response> CgiHandler::serve(const Request& req) {
     std::string scriptPath;
     std::string pathInfo;
-    Logger& log = Logger::instance();
     LOG_INFO("cgiHandler serve: function invoked");
     if (!isCgiTarget(req, &scriptPath, &pathInfo)) {
         LOG_WARN("cgiHandler serve: cannot find CgiTarget");
@@ -49,7 +48,6 @@ Either<IAction*, Response> CgiHandler::prepareCgi(const Request& req) {
     std::vector<std::string> argv;
     argv.push_back(full);
 
-    const std::vector<char>& stdinBody = req.getBody();
     PreparedCgi pc;
     pc.argv = argv;
     pc.env  = env;

--- a/src/http/handler/file/cgi_execute.cpp
+++ b/src/http/handler/file/cgi_execute.cpp
@@ -196,9 +196,9 @@ bool doWrite(pid_t pid, int wfd, int rfd, const char* ptr, ssize_t remain) {
     while (remain > 0) {
         const ssize_t byte = write(wfd, ptr, static_cast<size_t>(remain));
         if (byte < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
+            // if (errno == EINTR) {
+            //     continue;
+            // }
             close(wfd);
             close(rfd);
             (void)waitpid(pid, 0, 0);
@@ -217,9 +217,9 @@ bool doRead(pid_t pid, int rfd, std::string* out) {
         char buf[kBufSize];
         const ssize_t byte = read(rfd, buf, sizeof(buf));
         if (byte < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
+            // if (errno == EINTR) {
+            //     continue;
+            // }
             close(rfd);
             (void)waitpid(pid, 0, 0);
             return false;

--- a/src/http/handler/file/cgi_target.cpp
+++ b/src/http/handler/file/cgi_target.cpp
@@ -13,14 +13,14 @@ namespace {
 // utils    
 bool initCheck(const Request& req, std::string* scriptPath,
                std::string* pathInfo);
-bool checkIsUnderRoot(const std::string& root, const std::string& norm);
-bool splitScriptAndPathInfo(const std::string& root, const std::string& norm,
-                            std::string* scriptPath, std::string* pathInfo);
-bool findScriptPrefix(const std::string& abs, std::string* scriptFsPath,
-                      std::string* pathInfoSuffix);
-bool isRegularFile(const std::string& file);
-bool isExecutableFile(const std::string& file);
-std::string fsToVirtual(const std::string& root, const std::string& fileSystem);
+// bool checkIsUnderRoot(const std::string& root, const std::string& norm);
+// bool splitScriptAndPathInfo(const std::string& root, const std::string& norm,
+//                             std::string* scriptPath, std::string* pathInfo);
+// bool findScriptPrefix(const std::string& abs, std::string* scriptFsPath,
+//                       std::string* pathInfoSuffix);
+// bool isRegularFile(const std::string& file);
+// bool isExecutableFile(const std::string& file);
+// std::string fsToVirtual(const std::string& root, const std::string& fileSystem);
 
 }  // namespace
 
@@ -96,95 +96,95 @@ bool initCheck(const Request& req, std::string* scriptPath,
     return method == kMethodGet || method == kMethodPost;
 }
 
-bool checkIsUnderRoot(const std::string& root, const std::string& norm) {
-    if (root.empty()) {
-        return false;
-    }
-    return utils::path::isPathUnderRoot(root, norm);
-}
+// bool checkIsUnderRoot(const std::string& root, const std::string& norm) {
+//     if (root.empty()) {
+//         return false;
+//     }
+//     return utils::path::isPathUnderRoot(root, norm);
+// }
 
-bool splitScriptAndPathInfo(const std::string& root, const std::string& norm,
-                            std::string* scriptPath, std::string* pathInfo) {
-    if (scriptPath == NULL || pathInfo == NULL) {
-        return false;
-    }
+// bool splitScriptAndPathInfo(const std::string& root, const std::string& norm,
+//                             std::string* scriptPath, std::string* pathInfo) {
+//     if (scriptPath == NULL || pathInfo == NULL) {
+//         return false;
+//     }
 
-    std::string scriptFsPath;
-    std::string pathInfoSuffix;
-    if (!findScriptPrefix(norm, &scriptFsPath, &pathInfoSuffix)) {
-        return false;
-    }
-    // 拡張子チェック追加?
-    if (!isExecutableFile(scriptFsPath)) {
-        return false;
-    }
+//     std::string scriptFsPath;
+//     std::string pathInfoSuffix;
+//     if (!findScriptPrefix(norm, &scriptFsPath, &pathInfoSuffix)) {
+//         return false;
+//     }
+//     // 拡張子チェック追加?
+//     if (!isExecutableFile(scriptFsPath)) {
+//         return false;
+//     }
 
-    const std::string virt = fsToVirtual(root, scriptFsPath);
-    if (virt.empty()) {
-        return false;
-    }
+//     const std::string virt = fsToVirtual(root, scriptFsPath);
+//     if (virt.empty()) {
+//         return false;
+//     }
 
-    *scriptPath = virt;
-    *pathInfo = pathInfoSuffix;  // possible '/'start
+//     *scriptPath = virt;
+//     *pathInfo = pathInfoSuffix;  // possible '/'start
 
-    return true;
-}
+//     return true;
+// }
 
 // 末尾からディレクトリを削っていき、最長一致の既存ファイルを見つける
 // 見つかったら scriptFs=そのファイル, rest=残り（先頭'/'含む or 空）
-bool findScriptPrefix(const std::string& abs, std::string* scriptFsPath,
-                      std::string* pathInfoSuffix) {
-    if (scriptFsPath == 0 || pathInfoSuffix == 0) {
-        return false;
-    }
-    std::string cur = abs;
-    while (true) {
-        if (isRegularFile(cur)) {
-            *scriptFsPath = cur;
-            if (abs.size() > cur.size()) {
-                *pathInfoSuffix = abs.substr(cur.size());
-            } else {
-                pathInfoSuffix->clear();
-            }
-            return true;
-        }
-        const std::string::size_type pos = cur.rfind('/');
-        if (pos == std::string::npos || pos == 0) {
-            return false;
-        }
-        cur = cur.substr(0, pos);
-    }
-}
+// bool findScriptPrefix(const std::string& abs, std::string* scriptFsPath,
+//                       std::string* pathInfoSuffix) {
+//     if (scriptFsPath == 0 || pathInfoSuffix == 0) {
+//         return false;
+//     }
+//     std::string cur = abs;
+//     while (true) {
+//         if (isRegularFile(cur)) {
+//             *scriptFsPath = cur;
+//             if (abs.size() > cur.size()) {
+//                 *pathInfoSuffix = abs.substr(cur.size());
+//             } else {
+//                 pathInfoSuffix->clear();
+//             }
+//             return true;
+//         }
+//         const std::string::size_type pos = cur.rfind('/');
+//         if (pos == std::string::npos || pos == 0) {
+//             return false;
+//         }
+//         cur = cur.substr(0, pos);
+//     }
+// }
 
 // 正規ファイルか
-bool isRegularFile(const std::string& file) {
-    struct stat sta;
+// bool isRegularFile(const std::string& file) {
+//     struct stat sta;
 
-    if (stat(file.c_str(), &sta) != 0) {
-        return false;
-    }
-    return S_ISREG(sta.st_mode);
-}
+//     if (stat(file.c_str(), &sta) != 0) {
+//         return false;
+//     }
+//     return S_ISREG(sta.st_mode);
+// }
 
 // 実行可能ファイルか
-bool isExecutableFile(const std::string& file) {
-    if (!isRegularFile(file)) {
-        return false;
-    }
-    return access(file.c_str(), X_OK) == 0;
-}
+// bool isExecutableFile(const std::string& file) {
+//     if (!isRegularFile(file)) {
+//         return false;
+//     }
+//     return access(file.c_str(), X_OK) == 0;
+// }
 
-std::string fsToVirtual(const std::string& root,
-                        const std::string& fileSystem) {
-    if (fileSystem.compare(0, root.size(), root) != 0) {
-        return std::string();
-    }
-    std::string virt = fileSystem.substr(root.size());
-    if (virt.empty() || virt[0] != '/') {
-        virt.insert(virt.begin(), '/');
-    }
-    return virt;
-}
+// std::string fsToVirtual(const std::string& root,
+//                         const std::string& fileSystem) {
+//     if (fileSystem.compare(0, root.size(), root) != 0) {
+//         return std::string();
+//     }
+//     std::string virt = fileSystem.substr(root.size());
+//     if (virt.empty() || virt[0] != '/') {
+//         virt.insert(virt.begin(), '/');
+//     }
+//     return virt;
+// }
 
 }  // namespace
 

--- a/src/http/handler/file/fileOrCgi.cpp
+++ b/src/http/handler/file/fileOrCgi.cpp
@@ -1,4 +1,3 @@
-#warning "fileOrCgi.cpp is compiled"
 #include "http/handler/file/fileOrCgi.hpp"
 
 #include "http/request/request.hpp"

--- a/src/http/handler/router/internal.cpp
+++ b/src/http/handler/router/internal.cpp
@@ -26,7 +26,6 @@ namespace http {
         }
 
         const std::string& matchedPath = matchResult.unwrap(); // "/" や "/upload" や ".py"
-        Logger& log = Logger::instance();
         LOG_INFO("MatchedPath information:" + matchedPath + "");
 
         // IHandler* handler = registry_.findHandler(req.getMethod(), matchedPath);

--- a/src/http/request/read/length_body.cpp
+++ b/src/http/request/read/length_body.cpp
@@ -27,6 +27,7 @@ TransitionResult ReadingRequestBodyLengthState::handle(ReadContext& ctx,
         return done(std::string(""));
     }
     if (contentLength_ > clientMaxBodySize_) {
+        buf.clear();
         return error(tr, error::kRequestEntityTooLarge);
     }
     if (!ensureData(buf, tr)) {

--- a/src/io/handler/CgiStdinHandler.cpp
+++ b/src/io/handler/CgiStdinHandler.cpp
@@ -20,13 +20,10 @@ void CgiStdinHandler::onEvent(const FdEntry& e, uint32_t m) {
     if ((m & EPOLLOUT) && ctx->getFdIn() >= 0 && ctx->getStdinBody()) {
         io::FdWriter w(ctx->getFdIn());
         const std::vector<char>& body = *ctx->getStdinBody();
-        while (ctx->getWritten() < body.size()) {
-            io::FdWriter::WriteResult wr = w.write(&body[ctx->getWritten()], body.size() - ctx->getWritten());
-            const std::size_t n = wr.unwrap();
-            if (n == 0)
-                break;
-            ctx->setWritten(ctx->getWritten() + n);
-        }
+        io::FdWriter::WriteResult wr = w.write(&body[ctx->getWritten()], body.size() - ctx->getWritten());
+        const std::size_t n = wr.unwrap();
+        ctx->setLastRecv(std::time(0));
+        ctx->setWritten(ctx->getWritten() + n);
         if (ctx->getWritten() >= body.size()) {
             srv_->applyDispatchResult(*c, DispatchResult::CgiCloseIn());
         }

--- a/src/io/handler/CgiStdoutHandler.cpp
+++ b/src/io/handler/CgiStdoutHandler.cpp
@@ -17,7 +17,7 @@ void CgiStdoutHandler::onEvent(const FdEntry& e, uint32_t m) {
     if (m & EPOLLIN) {
         io::FdReader r(c->getCgi()->getFdOut());
         char buf[8192];
-        for (;;) {
+        // for (;;) {
             io::FdReader::ReadResult rr = r.read(buf, sizeof(buf));
             const size_t n = rr.unwrap();
             if (n == 0) {
@@ -27,10 +27,10 @@ void CgiStdoutHandler::onEvent(const FdEntry& e, uint32_t m) {
                     srv_->applyDispatchResult(*c, d1);
                     srv_->applyDispatchResult(*c, DispatchResult::CgiCloseOut());
                 }
-                break;
+                // break;
             }
             c->getCgi()->setRawOut(c->getCgi()->getRawOut().append(buf, buf + n));
-        }
+        // }
     }
     if (m & EPOLLHUP) {
         DispatchResult d1 = srv_->getDispatcher()->finalizeCgi(*c);

--- a/src/io/handler/CgiStdoutHandler.cpp
+++ b/src/io/handler/CgiStdoutHandler.cpp
@@ -17,20 +17,18 @@ void CgiStdoutHandler::onEvent(const FdEntry& e, uint32_t m) {
     if (m & EPOLLIN) {
         io::FdReader r(c->getCgi()->getFdOut());
         char buf[8192];
-        // for (;;) {
-            io::FdReader::ReadResult rr = r.read(buf, sizeof(buf));
-            const size_t n = rr.unwrap();
-            if (n == 0) {
-                if (r.eof()) {
-                    LOG_DEBUG("CgiStdoutHandler::onEvent: CGI response creation finished");
-                    DispatchResult d1 = srv_->getDispatcher()->finalizeCgi(*c);
-                    srv_->applyDispatchResult(*c, d1);
-                    srv_->applyDispatchResult(*c, DispatchResult::CgiCloseOut());
-                }
-                // break;
+        io::FdReader::ReadResult rr = r.read(buf, sizeof(buf));
+        const size_t n = rr.unwrap();
+        c->getCgi()->setLastRecv(std::time(0));
+        if (n == 0) {
+            if (r.eof()) {
+                LOG_DEBUG("CgiStdoutHandler::onEvent: CGI response creation finished");
+                DispatchResult d1 = srv_->getDispatcher()->finalizeCgi(*c);
+                srv_->applyDispatchResult(*c, d1);
+                srv_->applyDispatchResult(*c, DispatchResult::CgiCloseOut());
             }
-            c->getCgi()->setRawOut(c->getCgi()->getRawOut().append(buf, buf + n));
-        // }
+        }
+        c->getCgi()->setRawOut(c->getCgi()->getRawOut().append(buf, buf + n));
     }
     if (m & EPOLLHUP) {
         DispatchResult d1 = srv_->getDispatcher()->finalizeCgi(*c);

--- a/src/io/handler/ClientHandler.cpp
+++ b/src/io/handler/ClientHandler.cpp
@@ -11,8 +11,15 @@ void ClientHandler::onEvent(const FdEntry& e, uint32_t m){
     if (!c) {
         return;
     }
-    // 致命エラー
     if (m & EPOLLERR) {
+        // Since getsockopt is forbidden function, comment out. But if you want to see detail you can uncomment.
+        int err = 0;
+        socklen_t len = sizeof(err);
+        if (getsockopt(e.fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0) {
+            if (err != 0) {
+                LOG_ERROR("EPOLLERR detail: " + std::string(strerror(err)));
+            }
+        }
         LOG_ERROR("ClientHandler::onEvent: Epoll fatal error");
         handleHangup(*c); //Connection close
         return;
@@ -40,13 +47,8 @@ void ClientHandler::onEvent(const FdEntry& e, uint32_t m){
 }
 
 void ClientHandler::onReadable(Connection& c) {
-    // for (;;) {
-        ReadBuffer::LoadResult lr = c.getReadBuffer().load();
-        // if (lr.unwrap() == 0) {
-        //     break; // これ以上は読めない
-        // }
-        c.setLastRecv(std::time(0));
-    // }
+    ReadBuffer::LoadResult lr = c.getReadBuffer().load();
+    c.setLastRecv(std::time(0));
     for (;;) {
         const http::RequestReader::ReadRequestResult readRes = c.getRequestReader().readRequest(c.getReadBuffer());
         if (readRes.isErr()) {
@@ -82,17 +84,7 @@ void ClientHandler::maybeDispatch(Connection& c) {
 
 void ClientHandler::onWritable(Connection& c) {
     WriteBuffer &writeBuffer = c.getWriteBuffer();
-    // for (;;) {
-        types::Result<std::size_t, error::AppError>  writeRes = writeBuffer.flush();
-        // if (writeRes.isErr()) {
-        // 現状ここに入ることはない
-        //     handleWriteError(c, errno);
-        //     return; 
-        // }
-    //     if (writeRes.unwrap() == 0) {
-    //         break;
-    //     }
-    // }
+    types::Result<std::size_t, error::AppError>  writeRes = writeBuffer.flush();
     if (writeBuffer.isEmpty()) {
         if (c.hasPending()) {
             c.popFront();
@@ -133,13 +125,13 @@ void ClientHandler::failAndClose(Connection& c, const error::AppError& err) {
 //     srv_->applyDispatchResult(c, DispatchResult::Close());
 // }
 
-void ClientHandler::handleReadError(Connection& c, const error::AppError& err) {
-    // TODO: ここで err から errno 相当のコードやメッセージを取得できるならログる
-    // 例: int e = err.to_errno(); log("read error: %d", e);
-    (void)err;
-    // 読み I/O エラーは即クローズでよい（レスポンスは返さない）
-    srv_->applyDispatchResult(c, DispatchResult::Close());
-}
+// void ClientHandler::handleReadError(Connection& c, const error::AppError& err) {
+//     // TODO: ここで err から errno 相当のコードやメッセージを取得できるならログる
+//     // 例: int e = err.to_errno(); log("read error: %d", e);
+//     (void)err;
+//     // 読み I/O エラーは即クローズでよい（レスポンスは返さない）
+//     srv_->applyDispatchResult(c, DispatchResult::Close());
+// }
 
 // パース／前段バリデーションのエラーを HTTP ステータスへ
 http::HttpStatusCode ClientHandler::mapParseErrorToHttpStatus(error::AppError err) {

--- a/src/io/handler/ClientHandler.cpp
+++ b/src/io/handler/ClientHandler.cpp
@@ -13,13 +13,13 @@ void ClientHandler::onEvent(const FdEntry& e, uint32_t m){
     }
     if (m & EPOLLERR) {
         // Since getsockopt is forbidden function, comment out. But if you want to see detail you can uncomment.
-        int err = 0;
-        socklen_t len = sizeof(err);
-        if (getsockopt(e.fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0) {
-            if (err != 0) {
-                LOG_ERROR("EPOLLERR detail: " + std::string(strerror(err)));
-            }
-        }
+        // int err = 0;
+        // socklen_t len = sizeof(err);
+        // if (getsockopt(e.fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0) {
+        //     if (err != 0) {
+        //         LOG_ERROR("EPOLLERR detail: " + std::string(strerror(err)));
+        //     }
+        // }
         LOG_ERROR("ClientHandler::onEvent: Epoll fatal error");
         handleHangup(*c); //Connection close
         return;

--- a/src/io/input/read/buffer.cpp
+++ b/src/io/input/read/buffer.cpp
@@ -63,6 +63,11 @@ ReadBuffer::LoadResult ReadBuffer::load() {
     return OK(bytesRead);
 }
 
+
+void ReadBuffer::clear() {
+    buf_.clear();
+}
+
 size_t ReadBuffer::size() const {
     return buf_.size();
 }

--- a/src/io/input/reader/fd.cpp
+++ b/src/io/input/reader/fd.cpp
@@ -29,9 +29,9 @@ FdReader::ReadResult FdReader::read(char *buf, std::size_t nbyte) {
         return OK(static_cast<std::size_t>(0));
     }
     // need to delete
-    if (bytesRead == -1) {
-        LOG_WARN(::strerror(errno));
-    }
+    // if (bytesRead == -1) {
+    //     LOG_WARN(::strerror(errno));
+    // }
 
     return OK(static_cast<std::size_t>(0));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
 #include "config/config.hpp"
 #include "server/Server.hpp"
 #include "utils/logger.hpp"
+#include <csignal>
+
 
 int main(int argc, char** argv) {
         SET_LOG_LEVEL(Logger::kDebug);
         LOG_INFO("Server starting...");
+        std::signal(SIGPIPE, SIG_IGN);
         if (!Config::checkArgc(argc)) {
                 LOG_ERROR("Invalid number of arguments");
                 return (1);

--- a/src/server/connection/connection.cpp
+++ b/src/server/connection/connection.cpp
@@ -2,13 +2,6 @@
 #include <ctime>
 #include "io/input/reader/fd.hpp"
 
-// Connection::Connection(int fd, const ISocketAddr& peerAddr)
-//     : connSock_(fd, peerAddr),
-//       connState_(0),
-//       readBuffer_(connSock_),
-//       writeBuffer_(connSock_),
-//       lastRecv_(std::time(0)) {}
-
 Connection::Connection(int fd, const ISocketAddr& peerAddr,
                        http::config::IConfigResolver& resolver)
     : connSock_(fd, peerAddr)

--- a/src/server/connection/connection.cpp
+++ b/src/server/connection/connection.cpp
@@ -19,7 +19,9 @@ Connection::Connection(int fd, const ISocketAddr& peerAddr,
     , frontDispatched_(false)
     , closeAfterWrite_(false)
     , peerHalfClosed_(false)
-    , lastRecv_(std::time(0)) {}
+    , lastRecv_(std::time(0))
+    , cgi_(0)
+    , preparedCgi_(0) {}
 
 Connection::~Connection() {
     if (connState_) {

--- a/src/server/dispatcher/requestDispatcher.cpp
+++ b/src/server/dispatcher/requestDispatcher.cpp
@@ -99,6 +99,7 @@ http::Response RequestDispatcher::buildErrorResponse(
         VirtualServer* vs, http::HttpStatusCode status, const std::string& plain) {
     // TODO: vs に error_page 設定があればファイルを読み込み、
     //             body/Content-Type を差し替える処理をここに追加
+    (void)vs;
     http::ResponseBuilder rb;
     rb.status(status).header("Content-Type", "text/plain");
     rb.text(plain, status);

--- a/test/post_largetest.py
+++ b/test/post_largetest.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import requests
+import time
+import os
+
+URL = "http://127.0.0.101:8081/posttest.py"  # テスト対象の CGI URL
+SIZES_MB = [5, 10, 20, 50]  # 段階的に送信するサイズ（MB単位）
+
+def generate_data(size_mb):
+    """指定したサイズ（MB）の擬似データを生成"""
+    return os.urandom(size_mb * 1024 * 10)
+
+def test_post(size_mb):
+    data = generate_data(size_mb)
+    headers = {"Content-Type": "application/octet-stream"}
+
+    print(f"\n=== {size_mb}MB POST Test ===")
+    print(f"Sending {len(data)} bytes...")
+
+    start = time.time()
+    try:
+        res = requests.post(URL, headers=headers, data=data, timeout=60)
+        elapsed = time.time() - start
+
+        print(f"Status: {res.status_code}")
+        print(f"Elapsed: {elapsed:.2f} sec")
+        print(f"Response length: {len(res.content)} bytes")
+        print("Body preview:", res.text[:200].replace("\n", "\\n"))
+    except requests.exceptions.RequestException as e:
+        elapsed = time.time() - start
+        print(f"Error after {elapsed:.2f} sec: {e}")
+
+def main():
+    print("Starting large POST tests against:", URL)
+    for size in SIZES_MB:
+        test_post(size)
+
+if __name__ == "__main__":
+    main()

--- a/test/server/connection/connection_test.cpp
+++ b/test/server/connection/connection_test.cpp
@@ -142,11 +142,11 @@ TEST(ConnectionTest, TimeoutLogic_WorksAroundThreshold) {
     const std::time_t now = std::time(0);
 
     // 閾値未満 → false
-    conn.setLastRecv(now - (60 - 1)); // kTimeoutThresholdSec = 60 を想定
+    conn.setLastRecv(now - (Connection::kTimeoutThresholdSec - 1)); // kTimeoutThresholdSec = 60 を想定
     EXPECT_FALSE(conn.isTimeout());
 
     // 閾値超過 → true
-    conn.setLastRecv(now - (60 + 1));
+    conn.setLastRecv(now - (Connection::kTimeoutThresholdSec + 1));
     EXPECT_TRUE(conn.isTimeout());
 }
 

--- a/test/test_curl.sh
+++ b/test/test_curl.sh
@@ -9,10 +9,10 @@ CURL_OPTS="-v -s -w '%{http_code}\n'"
 
 # テストケース一覧
 tests=(
+  "http://$ipaddr:$port/index.html"
   "http://$ipaddr:$port/hello.py"
   "http://$ipaddr:$port/notfound"
   "http://$ipaddr:$port/cgi-bin/test.py"
-  "http://$ipaddr:$port/index.html"
 )
 
 echo "Running GET curl tests against $ipaddr:$port"

--- a/test/test_curl.sh
+++ b/test/test_curl.sh
@@ -1,27 +1,47 @@
 #!/bin/bash
-# test_all.sh
 
 ipaddr="127.0.0.101"
 port=8081
+siegetestsec=30
 
-# 共通オプション
-CURL_OPTS="-v -s -w '%{http_code}\n'"
+CURL_OPTS="-v -w '%{http_code}\n'"
 
-# テストケース一覧
+dd if=/dev/zero of=bigfile_100M.bin bs=1M count=100
+dd if=/dev/zero of=bigfile_1M.bin bs=1M count=1
+dd if=/dev/zero of=middlefile_512K.bin bs=512K count=1
+dd if=/dev/zero of=middlefile_1000000b.bin bs=999785 count=1
+
+# GET テスト
 tests=(
   "http://$ipaddr:$port/index.html"
   "http://$ipaddr:$port/hello.py"
   "http://$ipaddr:$port/notfound"
-  "http://$ipaddr:$port/cgi-bin/test.py"
 )
 
-echo "Running GET curl tests against $ipaddr:$port"
-echo "----------------------------------------"
-
+echo "Running GET tests..."
 for url in "${tests[@]}"; do
   echo "Testing: $url"
-  code=$(curl $CURL_OPTS "$url")
+  code=$(curl $CURL_OPTS "$url" -s -o /dev/null)
   echo "→ HTTP Status: $code"
   echo
 done
-#heavy case/ CGI POST/ siege もできれば追加する
+
+# POST テスト
+post_files=(
+  "middlefile_512K.bin"
+  "middlefile_1000000b.bin"
+  "bigfile_1M.bin"
+  "bigfile_100M.bin"
+)
+
+for f in "${post_files[@]}"; do
+  echo "Testing upload: $f"
+  code=$(curl $CURL_OPTS -X POST -F "file=@$f" "http://$ipaddr:$port/upload" -s -o /dev/null)
+  echo "→ HTTP Status: $code"
+  echo
+done
+
+
+# Siege テスト
+# echo "Siege test will start. This takes 30sec..."
+# siege -c 10 -t $siegetestsec"s" "http://$ipaddr:$port/"

--- a/test/test_curl.sh
+++ b/test/test_curl.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# test_all.sh
+
+ipaddr="127.0.0.101"
+port=8081
+
+# 共通オプション
+CURL_OPTS="-v -s -w '%{http_code}\n'"
+
+# テストケース一覧
+tests=(
+  "http://$ipaddr:$port/hello.py"
+  "http://$ipaddr:$port/notfound"
+  "http://$ipaddr:$port/cgi-bin/test.py"
+  "http://$ipaddr:$port/index.html"
+)
+
+echo "Running GET curl tests against $ipaddr:$port"
+echo "----------------------------------------"
+
+for url in "${tests[@]}"; do
+  echo "Testing: $url"
+  code=$(curl $CURL_OPTS "$url")
+  echo "→ HTTP Status: $code"
+  echo
+done
+#heavy case/ CGI POST/ siege もできれば追加する

--- a/www/cgi-bin/posttest.py
+++ b/www/cgi-bin/posttest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+print("Status: 200 OK")
+print("Content-Type: text/plain; charset=utf-8")
+print()
+
+# 環境変数の確認
+print("REQUEST_METHOD:", os.environ.get("REQUEST_METHOD"))
+print("CONTENT_TYPE:", os.environ.get("CONTENT_TYPE"))
+print("CONTENT_LENGTH:", os.environ.get("CONTENT_LENGTH"))
+
+# 標準入力（ボディ）を読み取る
+body = sys.stdin.read()
+print("BODY:", body)


### PR DESCRIPTION
## 概要 / Overview

- read/write のループを外しました。
- buf.clear を追加しました
- siege でのテスト後に cgi を実行すると segfault で落ちてしまう問題を修正しました
- curl の get のみですが簡易テストスクリプトを追加しました。
- 校舎 PC では warning が出ないよう修正しました
## 該当する issue

- #173 

## 変更内容

- 変更点
  - Connection に対して初期化の追加
  - read/write のループを削除
  - 不要な const や 使用されていない値の消込

## 影響範囲
- xxxxxx
- xxxxxx

## その他
